### PR TITLE
refactor(6 pages): Review code in design patterns

### DIFF
--- a/coded-layout/institutional_landing_page_guidance.html
+++ b/coded-layout/institutional_landing_page_guidance.html
@@ -161,12 +161,16 @@
     </div>
     <div class="ip-cover-img">
       <div class="container">
-        <div class="col-lg-7 col-md-7 row">
-          <h1 property="name" id="wb-cont">[Institution name]</h1>
-          <div class="clearfix"></div>
-          <p>Short description of the institution’s mandate.</p>
-          <div class="col-lg-12 col-md-12 row">
-            <a class="btn btn-call-to-action ip-btn" href="#">Super task button [optional]</a>
+        <div class="row">
+          <div class="col-md-7">
+            <h1 property="name" id="wb-cont">[Institution name]</h1>
+            <div class="clearfix"></div>
+            <p>Short description of the institution’s mandate.</p>
+            <div class="row">
+              <div class="col-md-12">
+                <a class="btn btn-call-to-action ip-btn" href="#">Super task button [optional]</a>
+              </div>
+            </div>
           </div>
         </div>
         <div class="row guidance-details">
@@ -641,4 +645,5 @@
     document.getElementById('submissionPage').value = location.href;
   </script>
 </body>
+
 </html>

--- a/coded-layout/institutional_landing_page_ng.html
+++ b/coded-layout/institutional_landing_page_ng.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><!
-[endif]-->
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
 <!--<![endif]-->
@@ -105,11 +104,12 @@
       </section>
       <div class="row">
         <div class="brand col-xs-5 col-md-4">
-          <a href="https://www.canada.ca/en.html"><img
-              src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="" /><span
-              class="wb-inv">
-              Government of Canada /
-              <span lang="fr">Gouvernement du Canada</span></span></a>
+          <a href="https://www.canada.ca/en.html">
+            <img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="" />
+            <span class="wb-inv">Government of Canada /
+              <span lang="fr">Gouvernement du Canada</span>
+            </span>
+          </a>
         </div>
         <section id="wb-srch" class="col-lg-8 text-right">
           <h2>Search</h2>
@@ -117,29 +117,22 @@
             <div class="form-group">
               <label for="wb-srch-q" class="wb-inv">Search website</label>
               <input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q
-                  form-control" name="q" type="search" value="" size="27" maxlength="150"
-                placeholder="Search Canada.ca" />
+                  form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca" />
               <input name="st" value="s" type="hidden" />
-
               <input name="num" value="10" type="hidden" />
-
               <input name="langs" value="eng" type="hidden" />
-
               <input name="st1rt" value="0" type="hidden" />
-
               <input name="s5bm3ts21rch" value="x" type="hidden" />
-
               <datalist id="wb-srch-q-ac">
                 <!--[if lte IE 9]><select><![endif]-->
-
                 <!--[if lte IE 9]></select><![endif]-->
               </datalist>
             </div>
-
             <div class="form-group submit">
               <button type="submit" id="wb-srch-sub" class="btn btn-primary
                   btn-small" name="wb-srch-sub">
-                <span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span>
+                <span class="glyphicon-search glyphicon"></span>
+                <span class="wb-inv">Search</span>
               </button>
             </div>
           </form>
@@ -153,25 +146,18 @@
           <span class="wb-inv">Main </span>Menu
           <span class="expicon glyphicon glyphicon-chevron-down"></span>
         </button>
-        <ul id="gc-mnu" role="menu" aria-orientation="vertical"
-          data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+        <ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the
-              workplace</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1"
-              href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration
-              and citizenship</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel
-              and tourism</a>
+            <a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business
-              and
-              industry</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a>
           </li>
           <li role="none presentation">
             <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a>
@@ -183,42 +169,28 @@
             <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment
-              and
-              natural resources</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National
-              security and
-              defence</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture,
-              history and
-              sport</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing,
-              justice
-              and emergencies</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport
-              and
-              infrastructure</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada
-              and the world</a>
+            <a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and
-              finances</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a>
           </li>
           <li role="none presentation">
-            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science
-              and
-              innovation</a>
+            <a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a>
           </li>
         </ul>
       </div>
@@ -229,21 +201,16 @@
         <ol class="breadcrumb">
           <li><a href="https://www.canada.ca/en.html">Home</a></li>
           <li>
-            <a href="https://www.canada.ca/en/government/about.html">About
-              Canada.ca</a>
+            <a href="https://www.canada.ca/en/government/about.html">About Canada.ca</a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/government/about/design-system.html">Canada.ca
-              design system</a>
+            <a href="https://www.canada.ca/en/government/about/design-system.html">Canada.ca design system</a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/government/about/design-system/pattern-library.html">Template
-              and pattern
-              library for Canada.ca</a>
+            <a href="https://www.canada.ca/en/government/about/design-system/pattern-library.html">Template and pattern library for Canada.ca</a>
           </li>
           <li>
-            <a href="https://design.canada.ca/mandatory-templates/institutional-profile-pages.html.html">Institutional
-              landing page</a>
+            <a href="https://design.canada.ca/mandatory-templates/institutional-profile-pages.html.html">Institutional landing page</a>
           </li>
         </ol>
       </div>
@@ -255,20 +222,21 @@
     <div class="container">
       <p>
         <a class="btn btn-primary" href="./institutional_landing_page_guidance.html">See guidance</a>
-        <a class="btn btn-default" href="../mandatory-templates/institutional-profile-pages-3.html">Back
-          to main
-          template page</a>
+        <a class="btn btn-default" href="../mandatory-templates/institutional-profile-pages-3.html">Back to main template page</a>
       </p>
     </div>
     <div class="ip-cover-img">
       <div class="container">
-        <div class="col-lg-7 col-md-7 row">
-          <h1 property="name" id="wb-cont">[Institution name]</h1>
-          <div class="clearfix"></div>
-          <p>Short description of the institution’s mandate.</p>
-          <div class="col-lg-12 col-md-12 row">
-            <a class="btn btn-call-to-action ip-btn" href="#">Super task
-              button [optional]</a>
+        <div class="row">
+          <div class="col-md-7">
+            <h1 property="name" id="wb-cont">[Institution name]</h1>
+            <div class="clearfix"></div>
+            <p>Short description of the institution’s mandate.</p>
+            <div class="row">
+              <div class="col-md-12">
+                <a class="btn btn-call-to-action ip-btn" href="#">Super task button [optional]</a>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -298,9 +266,9 @@
     </section>
 
     <div class="container">
-      <section class="gc-srvinfo col-md-12 mrgn-bttm-lg row">
-        <h2 class="wb-inv">Services and information</h2>
-        <div class="row">
+      <div class="row">
+        <section class="gc-srvinfo mrgn-bttm-lg">
+          <h2 class="wb-inv">Services and information</h2>
           <div class="wb-eqht">
             <section class="col-md-4">
               <h3><a href="#">[Hyperlink text]</a></h3>
@@ -378,8 +346,8 @@
             </section>
             <div class="clearfix"></div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
 
     <section class="most-requested well well-sm brdr-0">
@@ -387,13 +355,13 @@
         <div class="wb-eqht row">
           <h2 class="col-lg-3 h3">Contact us</h2>
           <span class="clearfix"></span>
-          <section class="col-lg-4 col-md-6 col-sm-6">
+          <section class="col-lg-4 col-sm-6">
             <h3 class="h5"><a href="#">Contact [Institution]</a></h3>
           </section>
-          <section class="col-lg-4 col-md-6 col-sm-6">
+          <section class="col-lg-4 col-sm-6">
             <h3 class="h5"><a href="#">[Top contact task 2]</a></h3>
           </section>
-          <section class="col-lg-4 col-md-6 col-sm-6">
+          <section class="col-lg-4 col-sm-6">
             <h3 class="h5"><a href="#">[Top contact task 3]</a></h3>
           </section>
         </div>
@@ -497,20 +465,16 @@
                 <br />
                 <ul>
                   <li>
-                    <a href="https://www.facebook.com/canrevagency" class="facebook" rel="external"><span
-                        class="wb-inv">Facebook</span></a>
+                    <a href="https://www.facebook.com/canrevagency" class="facebook" rel="external"><span class="wb-inv">Facebook</span></a>
                   </li>
                   <li>
-                    <a href="https://twitter.com/CanRevAgency" class="twitter" rel="external"><span
-                        class="wb-inv">Twitter</span></a>
+                    <a href="https://twitter.com/CanRevAgency" class="twitter" rel="external"><span class="wb-inv">Twitter</span></a>
                   </li>
                   <li>
-                    <a href="https://www.youtube.com/user/CanRevAgency" class="youtube" rel="external"><span
-                        class="wb-inv">YouTube</span></a>
+                    <a href="https://www.youtube.com/user/CanRevAgency" class="youtube" rel="external"><span class="wb-inv">YouTube</span></a>
                   </li>
                   <li>
-                    <a href="https://www.linkedin.com/company/cra-arc" class="linkedin" rel="external"><span
-                        class="wb-inv">LinkedIn</span></a>
+                    <a href="https://www.linkedin.com/company/cra-arc" class="linkedin" rel="external"><span class="wb-inv">LinkedIn</span></a>
                   </li>
                 </ul>
               </section>
@@ -543,11 +507,6 @@
               <small class="feeds-date">YYYY-MM-DD HH:MM</small>
             </li>
           </ul>
-          <!-- json feed for news example
-          <ul class="feeds-cont list-unstyled lst-spcd">
-            <li> <a data-ajax="https://www.canada.ca/content/canadasite/api/nws/fds/en/web-feeds/revenue-agency.json" href="https://www.canada.ca/en/revenue-agency.atom.xml" rel="external">Canada Revenue Agency news items</a> </li>
-          </ul>
-        -->
           <p>More: <a href="#" class="admin">[Institution] news</a></p>
         </section>
 
@@ -555,28 +514,21 @@
           <h2 class="h3">Features</h2>
           <div class="row wb-eqht">
             <div class="col-md-6 mrgn-bttm-md">
-              <a class="figcaption hght-inhrt" href="#">
-                <figure class="well well-sm brdr-rds-0 hght-inhrt">
-                  <img class="img-responsive full-width" alt="#"
-                    src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png" />
-                  <figcaption class="h5">
-                    [Featured hyperlink text]
-                  </figcaption>
-                  <p>Brief description of the feature being promoted.</p>
-                </figure>
+              <a class="hght-inhrt" href="#">
+                <section class="well well-sm brdr-rds-0 hght-inhrt">
+                  <img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png" />
+                  <h3 class="h5 mrgn-lft-sm">[Featured hyperlink text]</h3>
+                  <p class="mrgn-lft-sm">Brief description of the feature being promoted.</p>
+                </section>
               </a>
             </div>
             <div class="col-md-6 mrgn-bttm-md">
-              <a class="figcaption hght-inhrt"
-                href="https://www.canada.ca/en/revenue-agency/campaigns/my-benefits-credits.html">
-                <figure class="well well-sm brdr-rds-0 hght-inhrt">
-                  <img class="img-responsive full-width" alt="#"
-                    src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png" />
-                  <figcaption class="h5">
-                    [Featured hyperlink text]
-                  </figcaption>
-                  <p>Brief description of the feature being promoted.</p>
-                </figure>
+              <a class="hght-inhrt" href="https://www.canada.ca/en/revenue-agency/campaigns/my-benefits-credits.html">
+                <section class="well well-sm brdr-rds-0 hght-inhrt">
+                  <img class="img-responsive full-width" alt="#" src="https://wet-boew.github.io/themes-dist/GCWeb/img/360x203.png" />
+                  <h3 class="h5 mrgn-lft-sm">[Featured hyperlink text]</h3>
+                  <p class="mrgn-lft-sm">Brief description of the feature being promoted.</p>
+                </section>
               </a>
             </div>
           </div>
@@ -588,8 +540,7 @@
       <div class="row">
         <div class="col-sm-6 col-md-5 col-lg-4">
           <details class="brdr-0">
-            <summary class="btn btn-default text-center">Report a problem on
-              this page</summary>
+            <summary class="btn btn-default text-center">Report a problem on this page</summary>
             <div class="well row">
               <div class="gc-rprt-prblm">
                 <div class="gc-rprt-prblm-frm gc-rprt-prblm-tggl">
@@ -600,66 +551,55 @@
                         </span>
                       </legend>
                       <div class="checkbox">
-                        <label for="problem1"><input type="checkbox" data-reveal="#broken" name="problem"
-                            value="Something is broken" id="problem1" />Something
-                          is broken</label>
+                        <label for="problem1"><input type="checkbox" data-reveal="#broken" name="problem" value="Something is broken" id="problem1" />Something is broken</label>
                       </div>
                       <div class="form-group hide" id="broken">
-                        <label for="problem1-detail">Provide more details
-                          (optional):</label>
+                        <label for="problem1-detail">Provide more details (optional):</label>
                         <input type="text" class="form-control full-width" id="problem1-detail" />
                       </div>
                       <div class="checkbox">
-                        <label for="problem2"><input type="checkbox" data-reveal="#spelling" name="problem"
-                            value="It has spelling or grammar mistakes" id="problem2" />The page has spelling or grammar
-                          mistakes</label>
+                        <label for="problem2"><input type="checkbox" data-reveal="#spelling" name="problem" value="It
+                              has spelling or grammar mistakes" id="problem2" />The page has spelling or grammar mistakes</label>
                       </div>
                       <div class="form-group hide" id="spelling">
-                        <label for="problem2-detail">Provide more details
-                          (optional):</label>
+                        <label for="problem2-detail">Provide more details (optional):</label>
                         <input type="text" class="form-control full-width" id="problem2-detail" />
                       </div>
                       <div class="checkbox">
-                        <label for="problem3"><input type="checkbox" data-reveal="#wrong" name="problem"
-                            value="The information is wrong" id="problem3" />The
-                          information is wrong</label>
+                        <label for="problem3"><input type="checkbox" data-reveal="#wrong" name="problem" value="The
+                              information is wrong" id="problem3" />The information is wrong</label>
                       </div>
                       <div class="form-group hide" id="wrong">
-                        <label for="problem3-detail">Provide more details
-                          (optional):</label>
+                        <label for="problem3-detail">Provide more details (optional):</label>
                         <input type="text" class="form-control full-width" id="problem3-detail" />
                       </div>
                       <div class="checkbox">
-                        <label for="problem4"><input type="checkbox" data-reveal="#outdated" name="problem"
-                            value="The information is outdated" id="problem4" />The information is outdated</label>
+                        <label for="problem4"><input type="checkbox" data-reveal="#outdated" name="problem" value="The
+                              information is outdated" id="problem4" />The information is outdated</label>
                       </div>
                       <div class="form-group hide" id="outdated">
-                        <label for="problem4-detail">Provide more details
-                          (optional):</label>
+                        <label for="problem4-detail">Provide more details (optional):</label>
                         <input type="text" class="form-control full-width" id="problem4-detail" />
                       </div>
                       <div class="checkbox">
-                        <label for="problem5"><input type="checkbox" data-reveal="#find" name="problem"
-                            value="I can’t find what I’m looking for" id="problem5" />I can’t find what I’m looking
-                          for</label>
+                        <label for="problem5"><input type="checkbox" data-reveal="#find" name="problem" value="I can’t
+                              find what I’m looking for" id="problem5" />I can’t find what I’m looking for</label>
                       </div>
                       <div class="form-group hide" id="find">
-                        <label for="problem5-detail">Describe what you’re
-                          looking for (optional):</label>
+                        <label for="problem5-detail">Describe what you’re looking for (optional):</label>
                         <input type="text" class="form-control full-width" id="problem5-detail" />
                       </div>
                       <div class="checkbox">
-                        <label for="problem6"><input type="checkbox" data-reveal="#confusing" name="problem"
-                            value="It’s confusing" id="problem6" />Other</label>
+                        <label for="problem6"><input type="checkbox" data-reveal="#confusing" name="problem" value="It’s confusing" id="problem6" />Other</label>
                       </div>
                       <div class="form-group hide" id="confusing">
-                        <label for="problem6-detail">Provide more details
-                          (optional):</label>
+                        <label for="problem6-detail">Provide more details (optional):</label>
                         <input type="text" class="form-control full-width" id="problem6-detail" />
                       </div>
                     </fieldset>
-                    <button type="submit" class="btn btn-primary wb-toggle" data-toggle='{" stateOff" :"hide" ,"stateOn" :"show" ,"selector"
-                        :".gc-rprt-prblm-tggl" }'>
+                    <button type="submit" class="btn btn-primary wb-toggle" data-toggle='{" stateOff" :" hide" ," stateOn" :" show"
+                        ," selector"
+                        :" .gc-rprt-prblm-tggl" }'>
                       Submit
                     </button>
                   </form>
@@ -668,8 +608,7 @@
                   <h3>Thank you for your help!</h3>
                   <p>
                     You will not receive a reply. For enquiries, please
-                    <a href="https://test.canada.ca/canada-child-benefit-2/validation/contact.html">contact
-                      us</a>.
+                    <a href="https://test.canada.ca/canada-child-benefit-2/validation/contact.html">contact us</a>.
                   </p>
                 </div>
               </div>
@@ -677,7 +616,8 @@
           </details>
         </div>
         <div class="wb-share col-sm-4 col-md-3 col-sm-offset-2 col-md-offset-4
-            col-lg-offset-5" data-wb-share='{" lnkClass" :"btn btn-default btn-block" }'></div>
+            col-lg-offset-5" data-wb-share='{" lnkClass" :" btn btn-default
+            btn-block" }'></div>
       </div>
       <dl id="wb-dtmd">
         <dt>Date modified:&#32;</dt>
@@ -695,26 +635,21 @@
             <a href="https://www.canada.ca/en/contact.html">Contact us</a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/government/dept.html">Departments
-              and agencies</a>
+            <a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/government/publicservice.html">Public
-              service and military</a>
+            <a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
           </li>
           <li><a href="https://www.canada.ca/en/news.html">News</a></li>
           <li>
-            <a href="https://www.canada.ca/en/government/system/laws.html">Treaties,
-              laws and regulations</a>
+            <a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide
-              reporting</a>
+            <a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
           </li>
           <li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
           <li>
-            <a href="https://www.canada.ca/en/government/system.html">How
-              government works</a>
+            <a href="https://www.canada.ca/en/government/system.html">How government works</a>
           </li>
           <li><a href="https://open.canada.ca/en/">Open government</a></li>
         </ul>
@@ -730,16 +665,13 @@
                 <a href="https://www.canada.ca/en/social.html">Social media</a>
               </li>
               <li>
-                <a href="https://www.canada.ca/en/mobile.html">Mobile
-                  applications</a>
+                <a href="https://www.canada.ca/en/mobile.html">Mobile applications</a>
               </li>
               <li>
-                <a href="https://www1.canada.ca/en/newsite.html">About
-                  Canada.ca</a>
+                <a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a>
               </li>
               <li>
-                <a href="https://www.canada.ca/en/transparency/terms.html">Terms
-                  and conditions</a>
+                <a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a>
               </li>
               <li>
                 <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
@@ -747,12 +679,12 @@
             </ul>
           </nav>
           <div class="col-xs-6 visible-sm visible-xs tofpg">
-            <a href="#wb-cont">Top of Page <span class="glyphicon
+            <a href="#wb-cont">Top of Page
+              <span class="glyphicon
                   glyphicon-chevron-up"></span></a>
           </div>
           <div class="col-xs-6 col-md-3 col-lg-2 text-right">
-            <img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg"
-              alt="Symbol of the Government of Canada" />
+            <img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada" />
           </div>
         </div>
       </div>

--- a/coded-layout/transparency_guidance.html
+++ b/coded-layout/transparency_guidance.html
@@ -2,375 +2,373 @@
 <!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
-<!--<![endif]-->
-<head>
-	<meta charset="utf-8">
-	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-	<title>Transparency and corporate reporting page - Canada.ca recommended template - Canada.ca</title>
-	<meta content="width=device-width,initial-scale=1" name="viewport">
-	<!--[if gte IE 9 | !IE ]><!-->
-	<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-	<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
-	<link rel="stylesheet" href="../css/custom.css">
-	<link rel="stylesheet" href="../css/ip.css">
-	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
 	<!--<![endif]-->
-	<!--[if lt IE 9]>
+	<head>
+		<meta charset="utf-8">
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+			wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+		<title>Transparency and corporate reporting page - Canada.ca recommended template - Canada.ca</title>
+		<meta content="width=device-width,initial-scale=1" name="viewport">
+		<!--[if gte IE 9 | !IE ]><!-->
+		<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+		<link rel="stylesheet" href="../css/custom.css">
+		<link rel="stylesheet" href="../css/ip.css">
+		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+		<!--<![endif]-->
+		<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-	<!--[if lte IE 9]>
+		<!--[if lte IE 9]>
 		<![endif]-->
-	<noscript>
-		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag() { dataLayer.push(arguments); }
-		gtag('js', new Date());
-		gtag('config', 'UA-105628416-2');
-	</script>
-	<style>
-		/* added to detail summaries inside the code to remove the bottom spacing */
-		.pattern-demo-code-ex details {
-			margin-bottom: 0px !important;
-		}
+		<noscript>
+			<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() { dataLayer.push(arguments); }
+			gtag('js', new Date());
+			gtag('config', 'UA-105628416-2');
+		</script>
+		<style>
+			/* added to detail summaries inside the code to remove the bottom spacing */
+			.pattern-demo-code-ex details {
+				margin-bottom: 0px !important;
+			}
 
-		.pattern-demo-code-ex .featured {
-			margin-left: .07em !important;
-			margin-right: .07em !important;
-		}
+			.pattern-demo-code-ex .featured {
+				margin-left: .07em !important;
+				margin-right: .07em !important;
+			}
 
-		/* .pattern-demo-code-ex .gc-prtts {
-		width: 99%;
-	} */
+			.pattern-demo {
+				padding: 0px !important;
+				margin: 0px !important;
+				border: none !important;
+			}
 
-		.pattern-demo {
-			padding: 0px !important;
-			margin: 0px !important;
-			border: none !important;
-		}
+			.pattern-demo-code-ex {
+				margin-left: -35px !important;
+				margin-right: -35px !important;
+			}
 
-		.pattern-demo-code-ex {
-			margin-left: -35px !important;
-			margin-right: -35px !important;
-		}
-
-		.guidance-details details,
-		.guidance-details summary,
-		.guidance-details details summary:focus,
-		.guidance-details details summary:hover {
-			background-color: white;
-		}
-	</style>
-</head>
-<body vocab="http://schema.org/" typeof="WebPage">
-	<ul id="wb-tphp">
-		<li class="wb-slc">
-			<a class="wb-sl" href="#wb-cont">Skip to main content</a>
-		</li>
-		<li class="wb-slc">
-			<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
-		</li>
-	</ul>
-	<header>
-		<div id="wb-bnr" class="container">
-			<section id="wb-lng" class="text-right">
-				<h2 class="wb-inv">Language selection</h2>
-				<div class="row">
-					<div class="col-md-12">
-						<ul class="list-inline margin-bottom-none">
-							<li><a lang="fr" href="https://conception.canada.ca/mise-en-page/transparence_directives.html">Français</a></li>
-						</ul>
-					</div>
-				</div>
-			</section>
-			<div class="row">
-				<div class="brand col-xs-5 col-md-4">
-					<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
-				</div>
-				<section id="wb-srch" class="col-lg-8 text-right">
-					<h2>Search</h2>
-					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
-						<div class="form-group">
-							<label for="wb-srch-q" class="wb-inv">Search website</label>
-							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
-							<input name="st" value="s" type="hidden" />
-							<input name="num" value="10" type="hidden" />
-							<input name="langs" value="eng" type="hidden" />
-							<input name="st1rt" value="0" type="hidden">
-							<input name="s5bm3ts21rch" value="x" type="hidden" />
-							<datalist id="wb-srch-q-ac">
-								<!--[if lte IE 9]><select><![endif]-->
-								<!--[if lte IE 9]></select><![endif]-->
-							</datalist>
-						</div>
-						<div class="form-group submit">
-							<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
-						</div>
-					</form>
-				</section>
-			</div>
-		</div>
-		<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-			<div class="container">
-				<h2 class="wb-inv">Menu</h2>
-				<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-				<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
-				</ul>
-			</div>
-		</nav>
-		<nav id="wb-bc" property="breadcrumb">
-			<h2>You are here:</h2>
-			<div class="container">
-				<ol class="breadcrumb">
-					<li><a href='https://www.canada.ca/en.html'>Home</a></li>
-					<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
-					<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
-					<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
-					<li><a href='https://design.canada.ca/recommended-templates/transparency.html'>Transparency and corporate reporting</a></li>
-				</ol>
-			</div>
-		</nav>
-	</header>
-	<!--/* Hide Nav; Hide Right Rail /*-->
-	<main role="main" property="mainContentOfPage" class="container">
-		<p><a class="btn btn-primary" href="./transparency_ng.html">Remove guidance</a> <a class="btn btn-default" href="../recommended-templates/transparency.html">Back to main template page</a></p>
-		<h1 property="name" id="wb-cont">Transparency: [Institution]</h1>
-		<section>
-			<p class="pagetag">Proactive disclosure of information, made public so that Canadians and Parliament are better able to hold the Government and public sector officials to account.</p>
-			<div class="row guidance-details">
-				<div class="col-md-8">
-					<details>
-						<summary><strong>Guidance:</strong> Page title and introduction <i class="fas fa-info-circle"></i></summary>
-						<section>
-							<h3>Title</h3>
-							<p>Use the applied title of the institution, as specified in the <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-eng.asp">Registry of Applied Titles</a>.</p>
-							<p>Use the legal title if the applied title is not available.</p>
-							<p>Do not use acronyms or abbreviations.</p>
-						</section>
-						<section>
-							<h3>Introduction text</h3>
-							<p>Use the suggested introduction text or adjust it to your situation.</p>
-							<p>Keep the introduction text short.</p>
-						</section>
-					</details>
-				</div>
-			</div>
-			<section>
-				<div class="row wb-eqht mrgn-bttm-md">
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Mandate letter from the Prime Minister</a></h2>
-							<p>Commitments and top priorities identified by the government</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Departmental Plan</a></h2>
-							<p>Performance goals for the coming fiscal year</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Departmental Results Report</a></h2>
-							<p>Performance targets met for the 2017-18 fiscal year</p>
-						</section>
-					</div>
-					<div class="clearfix"></div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Travel and hospitality expenses</a></h2>
-							<p>Disclosure of expenditures on Travel, Hospitality and Conferences</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Government contracts awarded</a></h2>
-							<p>Disclosure of contracts over $10,000</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Grants and contributions</a></h2>
-							<p>Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government</p>
-						</section>
-					</div>
-					<div class="clearfix"></div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Disclosure of serious wrongdoing in the workplace</a></h2>
-							<p>Disclosure of wrongdoing found to have been committed</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Reclassification of public service positions</a></h2>
-							<p>Disclosure of government positions that have been reclassified.</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Quarterly Financial Reports</a></h2>
-							<p>Quarterly spending at a departmental level</p>
-						</section>
-					</div>
-					<div class="clearfix"></div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Audits and evaluations</a></h2>
-							<p>Annual reports of audit and evaluations for programs and services at [institution]</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Consultations</a></h2>
-							<p>Public consultations and reports on completed consultations</p>
-						</section>
-					</div>
-					<div class="col-md-4">
-						<section class="gc-drmt">
-							<h2 class="h4"><a href="#">Briefing documents</a></h2>
-							<p>Briefing notes prepared for the President, Secretary and senior managers</p>
-						</section>
-					</div>
-				</div>
-				<div class="row guidance-details">
-					<div class="col-md-8">
-						<details>
-							<summary><strong>Guidance:</strong> Services and information <i class="fas fa-info-circle"></i></summary>
-
-							<section>
-								<p>Adjust the items in this section to your needs.</p>
-								<p>Use the <a href="../common-design-patterns/services-information.html">Services and information</a> pattern.</li>
-							</section>
-
-						</details>
-					</div>
-				</div>
-			</section>
-			<section>
-				<div>
-					<div class="row mrgn-bttm-lg">
+			.guidance-details details,
+			.guidance-details summary,
+			.guidance-details details summary:focus,
+			.guidance-details details summary:hover {
+				background-color: white;
+			}
+		</style>
+	</head>
+	<body vocab="http://schema.org/" typeof="WebPage">
+		<ul id="wb-tphp">
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-cont">Skip to main content</a>
+			</li>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
+			</li>
+		</ul>
+		<header>
+			<div id="wb-bnr" class="container">
+				<section id="wb-lng" class="text-right">
+					<h2 class="wb-inv">Language selection</h2>
+					<div class="row">
 						<div class="col-md-12">
-							<section class="mrgn-bttm-lg">
-								<h2>Didn’t find what you were looking for</h2>
-								<p>Make an access to information or personal information request (ATIP request)</p>
-								<ul class="list-unstyled">
-									<li class="pull-left mrgn-rght-lg"><a class="btn btn-primary" href="#">Make a request</a></li>
-									<li class="pull-left mrgn-tp-sm"><a href="https://open.canada.ca/en/search/ati">Completed requests</a></li>
-								</ul>
-							</section>
+							<ul class="list-inline margin-bottom-none">
+								<li><a lang="fr" href="https://conception.canada.ca/mise-en-page/transparence_directives.html">Français</a></li>
+							</ul>
 						</div>
 					</div>
+				</section>
+				<div class="row">
+					<div class="brand col-xs-5 col-md-4">
+						<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
+					</div>
+					<section id="wb-srch" class="col-lg-8 text-right">
+						<h2>Search</h2>
+						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+							<div class="form-group">
+								<label for="wb-srch-q" class="wb-inv">Search website</label>
+								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
+								<input name="st" value="s" type="hidden" />
+								<input name="num" value="10" type="hidden" />
+								<input name="langs" value="eng" type="hidden" />
+								<input name="st1rt" value="0" type="hidden">
+								<input name="s5bm3ts21rch" value="x" type="hidden" />
+								<datalist id="wb-srch-q-ac">
+									<!--[if lte IE 9]><select><![endif]-->
+									<!--[if lte IE 9]></select><![endif]-->
+								</datalist>
+							</div>
+							<div class="form-group submit">
+								<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
+							</div>
+						</form>
+					</section>
 				</div>
+			</div>
+			<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+				<div class="container">
+					<h2 class="wb-inv">Menu</h2>
+					<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+					<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
+						<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
+					</ul>
+				</div>
+			</nav>
+			<nav id="wb-bc" property="breadcrumb">
+				<h2>You are here:</h2>
+				<div class="container">
+					<ol class="breadcrumb">
+						<li><a href='https://www.canada.ca/en.html'>Home</a></li>
+						<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
+						<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
+						<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
+						<li><a href='https://design.canada.ca/recommended-templates/transparency.html'>Transparency and corporate reporting</a></li>
+					</ol>
+				</div>
+			</nav>
+		</header>
+		<!--/* Hide Nav; Hide Right Rail /*-->
+		<main role="main" property="mainContentOfPage" class="container">
+			<p><a class="btn btn-primary" href="./transparency_ng.html">Remove guidance</a> <a class="btn btn-default" href="../recommended-templates/transparency.html">Back to main template page</a></p>
+			<h1 property="name" id="wb-cont">Transparency: [Institution]</h1>
+			<section>
+				<p class="pagetag">Proactive disclosure of information, made public so that Canadians and Parliament are better able to hold the Government and public sector officials to account.</p>
 				<div class="row guidance-details">
 					<div class="col-md-8">
 						<details>
-							<summary><strong>Guidance:</strong> ATIP requests <i class="fas fa-info-circle"></i></summary>
+							<summary><strong>Guidance:</strong> Page title and introduction <i class="fas fa-info-circle"></i></summary>
 							<section>
-								<p>Link the "Make a request" button to the page where people can make ATIP requests about your institution.</p>
-								<p>Link "Completed requests" to the Open Government portal. You can link to a pre-filtered list for your organization.</li>
+								<h3>Title</h3>
+								<p>Use the applied title of the institution, as specified in the <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-eng.asp">Registry of Applied Titles</a>.</p>
+								<p>Use the legal title if the applied title is not available.</p>
+								<p>Do not use acronyms or abbreviations.</p>
+							</section>
+							<section>
+								<h3>Introduction text</h3>
+								<p>Use the suggested introduction text or adjust it to your situation.</p>
+								<p>Keep the introduction text short.</p>
 							</section>
 						</details>
 					</div>
 				</div>
-			</section>
-		</section>
-		<div class="row pagedetails">
-			<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-				<div class="panel-pane pane-block pane-bean-report-problem-button">
-					<div class="pane-content">
-						<section>
-							<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
-								<div class="field-items">
-									<div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div>
-								</div>
+				<section>
+					<div class="row wb-eqht mrgn-bttm-md">
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Mandate letter from the Prime Minister</a></h2>
+								<p>Commitments and top priorities identified by the government</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Departmental Plan</a></h2>
+								<p>Performance goals for the coming fiscal year</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Departmental Results Report</a></h2>
+								<p>Performance targets met for the 2017-18 fiscal year</p>
+							</section>
+						</div>
+						<div class="clearfix"></div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Travel and hospitality expenses</a></h2>
+								<p>Disclosure of expenditures on Travel, Hospitality and Conferences</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Government contracts awarded</a></h2>
+								<p>Disclosure of contracts over $10,000</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Grants and contributions</a></h2>
+								<p>Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government</p>
+							</section>
+						</div>
+						<div class="clearfix"></div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Disclosure of serious wrongdoing in the workplace</a></h2>
+								<p>Disclosure of wrongdoing found to have been committed</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Reclassification of public service positions</a></h2>
+								<p>Disclosure of government positions that have been reclassified.</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Quarterly Financial Reports</a></h2>
+								<p>Quarterly spending at a departmental level</p>
+							</section>
+						</div>
+						<div class="clearfix"></div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Audits and evaluations</a></h2>
+								<p>Annual reports of audit and evaluations for programs and services at [institution]</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Consultations</a></h2>
+								<p>Public consultations and reports on completed consultations</p>
+							</section>
+						</div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Briefing documents</a></h2>
+								<p>Briefing notes prepared for the President, Secretary and senior managers</p>
+							</section>
+						</div>
+					</div>
+					<div class="row guidance-details">
+						<div class="col-md-8">
+							<details>
+								<summary><strong>Guidance:</strong> Services and information <i class="fas fa-info-circle"></i></summary>
+
+								<section>
+									<p>Adjust the items in this section to your needs.</p>
+									<p>Use the <a href="../common-design-patterns/services-information.html">Services and information</a> pattern.</li>
+								</section>
+
+							</details>
+						</div>
+					</div>
+				</section>
+				<section>
+					<div>
+						<div class="row mrgn-bttm-lg">
+							<div class="col-md-12">
+								<section class="mrgn-bttm-lg">
+									<h2>Didn’t find what you were looking for</h2>
+									<p>Make an access to information or personal information request (ATIP request)</p>
+									<ul class="list-unstyled">
+										<li class="pull-left mrgn-rght-lg"><a class="btn btn-primary" href="#">Make a request</a></li>
+										<li class="pull-left mrgn-tp-sm"><a href="https://open.canada.ca/en/search/ati">Completed requests</a></li>
+									</ul>
+								</section>
 							</div>
-						</section>
+						</div>
+					</div>
+					<div class="row guidance-details">
+						<div class="col-md-8">
+							<details>
+								<summary><strong>Guidance:</strong> ATIP requests <i class="fas fa-info-circle"></i></summary>
+								<section>
+									<p>Link the "Make a request" button to the page where people can make ATIP requests about your institution.</p>
+									<p>Link "Completed requests" to the Open Government portal. You can link to a pre-filtered list for your organization.</li>
+								</section>
+							</details>
+						</div>
+					</div>
+				</section>
+			</section>
+			<div class="row pagedetails">
+				<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+					<div class="panel-pane pane-block pane-bean-report-problem-button">
+						<div class="pane-content">
+							<section>
+								<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+									<div class="field-items">
+										<div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div>
+									</div>
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
+				<div class="col-sm-3 mrgn-tp-sm pull-right">
+					<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+				</div>
+				<div class="datemod col-xs-12 mrgn-tp-lg">
+					<dl id="wb-dtmd">
+						<dt>Date modified:</dt>
+						<dd>
+							<time property="dateModified">2018-09-19</time>
+						</dd>
+					</dl>
+				</div>
+			</div>
+		</main>
+		<footer id="wb-info">
+			<div class="landscape">
+				<nav class="container wb-navcurr">
+					<h2 class="wb-inv">About government</h2>
+					<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+						<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
+						<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
+						<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
+						<li><a href="https://www.canada.ca/en/news.html">News</a></li>
+						<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
+						<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
+						<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
+						<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
+						<li><a href="https://open.canada.ca/en/">Open government</a></li>
+					</ul>
+				</nav>
+			</div>
+			<div class="brand">
+				<div class="container">
+					<div class="row">
+						<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+							<h2 class="wb-inv">About this site</h2>
+							<ul>
+								<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
+								<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
+								<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
+								<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
+								<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+							</ul>
+						</nav>
+						<div class="col-xs-6 visible-sm visible-xs tofpg">
+							<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+						</div>
+						<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+							<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+						</div>
 					</div>
 				</div>
 			</div>
-			<div class="col-sm-3 mrgn-tp-sm pull-right">
-				<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-			</div>
-			<div class="datemod col-xs-12 mrgn-tp-lg">
-				<dl id="wb-dtmd">
-					<dt>Date modified:</dt>
-					<dd><time property="dateModified">2018-09-19</time></dd>
-				</dl>
-			</div>
-		</div>
-	</main>
-	<footer id="wb-info">
-		<div class="landscape">
-			<nav class="container wb-navcurr">
-				<h2 class="wb-inv">About government</h2>
-				<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-					<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
-					<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
-					<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
-					<li><a href="https://www.canada.ca/en/news.html">News</a></li>
-					<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
-					<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
-					<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
-					<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
-					<li><a href="https://open.canada.ca/en/">Open government</a></li>
-				</ul>
-			</nav>
-		</div>
-		<div class="brand">
-			<div class="container">
-				<div class="row">
-					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-						<h2 class="wb-inv">About this site</h2>
-						<ul>
-							<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
-							<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
-							<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
-							<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-							<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
-						</ul>
-					</nav>
-					<div class="col-xs-6 visible-sm visible-xs tofpg">
-						<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
-					</div>
-					<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-						<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
-					</div>
-				</div>
-			</div>
-		</div>
-	</footer>
-	<!--[if gte IE 9 | !IE ]><!-->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<!--<![endif]-->
-	<!--[if lt IE 9]>
-			<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
-			<![endif]-->
-	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-	<script>
-		document.getElementById('submissionPage').value = location.href;
-	</script>
-</body>
+		</footer>
+		<!--[if gte IE 9 | !IE ]><!-->
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+		<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+		<!--<![endif]-->
+		<!--[if lt IE 9]>
+				<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
+				<![endif]-->
+		<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+		<script>
+			document.getElementById('submissionPage').value = location.href;
+		</script>
+	</body>
 </html>

--- a/coded-layout/transparency_ng.html
+++ b/coded-layout/transparency_ng.html
@@ -1,402 +1,402 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
-<!--<![endif]-->
-<head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+	<!--<![endif]-->
+	<head>
+		<meta charset="utf-8">
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>Transparency and corporate reporting page - Canada.ca recommended template - Canada.ca</title>
-
-<meta content="width=device-width,initial-scale=1" name="viewport">
-
-<!--[if gte IE 9 | !IE ]><!-->
-<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
-<link rel="stylesheet" href="../css/ip.css">
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
-
-<!--<![endif]-->
-<!--[if lt IE 9]>
+		<meta content="width=device-width,initial-scale=1" name="viewport">
+		<!--[if gte IE 9 | !IE ]><!-->
+		<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
+		<link rel="stylesheet" href="../css/ip.css">
+		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+		<!--<![endif]-->
+		<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
-
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
-
-
+		<!--[if lte IE 9]>
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
-
-
- <!-- Global site tag (gtag.js) - Google Analytics -->
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
-
-<script>
-
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-
-  gtag('config', 'UA-105628416-2');
-
-</script>
-</head>
-<body vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-cont">Skip to main content</a>
-</li>
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Language selection</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-<li><a lang="fr" href="https://conception.canada.ca/mise-en-page/transparence_ng.html">Français</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-<h2>Search</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
-
-<div class="form-group">
-
-<label for="wb-srch-q" class="wb-inv">Search website</label>
-
-<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
-
-<input name="st" value="s" type="hidden"/>
-
-<input name="num" value="10" type="hidden"/>
-
-<input name="langs" value="eng" type="hidden"/>
-
-<input name="st1rt" value="0" type="hidden">
-
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
-
-<datalist id="wb-srch-q-ac">
-
-<!--[if lte IE 9]><select><![endif]-->
-
-<!--[if lte IE 9]></select><![endif]-->
-
-</datalist>
-
-</div>
-
-<div class="form-group submit">
-
-<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
-
-</div>
-
-</form>
-
-
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>You are here:</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/en.html'>Home</a></li>
-	<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
-  <li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
-	<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
-	<li><a href='https://design.canada.ca/recommended-templates/transparency.html'>Transparency and corporate reporting</a></li>
-</ol>
-</div>
-</nav>
-</header>
-
-<style> /* to move later */
-
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
-
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
-
-/* .pattern-demo-code-ex .gc-prtts {
-	width: 99%;
-} */
-
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
-
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
-
-
-
-</style>
-<!--/* Hide Nav; Hide Right Rail /*-->
-
-<main role="main" property="mainContentOfPage" class="container">
-	<p><a class="btn btn-primary" href="./transparency_guidance.html">See guidance</a>  <a class="btn btn-default" href="../recommended-templates/transparency.html">Back to main template page</a></p>
-
-<h1 property="name" id="wb-cont">Transparency: [Institution]</h1>
-<p class="pagetag">Proactive disclosure of information, made public so that Canadians and Parliament are better able to hold the Government and public sector officials to account.</p>
-<section>
- <div class="row wb-eqht mrgn-bttm-md">
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Mandate letter from the Prime Minister</a></h2>
-    <p>Commitments and top priorities identified by the government</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Departmental Plan</a></h2>
-    <p>Performance goals for the coming fiscal year</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Departmental Results Report</a></h2>
-    <p>Performance targets met for the 2017-18 fiscal year</p>
-   </section>
-  </div>
-  <div class="clearfix"></div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Travel and hospitality expenses</a></h2>
-    <p>Disclosure of expenditures on Travel, Hospitality and Conferences</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Government contracts awarded</a></h2>
-    <p>Disclosure of contracts over $10,000</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Grants and contributions</a></h2>
-    <p>Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government</p>
-   </section>
-  </div>
-  <div class="clearfix"></div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Disclosure of serious wrongdoing in the workplace</a></h2>
-    <p>Disclosure of wrongdoing found to have been committed</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Reclassification of public service positions</a></h2>
-    <p>Disclosure of government positions that have been reclassified.</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Quarterly Financial Reports</a></h2>
-    <p>Quarterly spending at a departmental level</p>
-   </section>
-  </div>
-  <div class="clearfix"></div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Audits and evaluations</a></h2>
-    <p>Annual reports of audit and evaluations for programs and services at [institution]</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Consultations</a></h2>
-    <p>Public consultations and reports on completed consultations</p>
-   </section>
-  </div>
-  <div class="col-md-4">
-   <section class="gc-drmt">
-    <h2 class="h4"><a href="#">Briefing documents</a></h2>
-    <p>Briefing notes prepared for the President, Secretary and senior managers</p>
-   </section>
-  </div>
-  </div>
-</section>
-<section>
- <div>
-  <div class="row mrgn-bttm-lg">
-   <div class="col-md-12">
-    <section class="mrgn-bttm-lg">
-     <h2>Didn’t find what you were looking for</h2>
-     <p>Make an access to information or personal information request (ATIP request)</p>
-     <ul class="list-unstyled">
-      <li class="pull-left mrgn-rght-lg"><a class="btn btn-primary" href="#">Make an ATIP request</a></li>
-      <li class="pull-left mrgn-tp-sm"><a href="https://open.canada.ca/en/search/ati">Completed requests</a></li>
-     </ul>
-    </section>
-   </div>
-  </div>
- </div>
-</section>
-
-
-
-
-
-
-
-			<!--<section>
-				<h2 id="examples">Working examples</h2>
-				<ul>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-en.html">English working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-fr.html">French working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-en.html">English working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-fr.html">French working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-				</ul>
+		<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'UA-105628416-2');
+		</script>
+		<style> /* to move later */
+			/* added to detail summaries inside the code to remove the bottom spacing */
+			.pattern-demo-code-ex details {
+				margin-bottom: 0px !important;
+			}
+			.pattern-demo-code-ex .featured {
+				margin-left: .07em !important;
+				margin-right: .07em !important;
+			}
+			.pattern-demo {
+				padding: 0px !important;
+				margin: 0px !important;
+				border: none !important;
+			}
+			.pattern-demo-code-ex {
+				margin-left: -35px !important;
+				margin-right: -35px !important;
+			}	
+		</style>
+	</head>
+	<body vocab="http://schema.org/" typeof="WebPage">
+		<ul id="wb-tphp">
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-cont">Skip to main content</a>
+			</li>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
+			</li>
+		</ul>
+		<header>
+			<div id="wb-bnr" class="container">
+				<section id="wb-lng" class="text-right">
+					<h2 class="wb-inv">Language selection</h2>
+					<div class="row">
+						<div class="col-md-12">
+							<ul class="list-inline margin-bottom-none">
+								<li>
+									<a lang="fr" href="https://conception.canada.ca/mise-en-page/transparence_ng.html">Français</a>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</section>
+				<div class="row">
+					<div class="brand col-xs-5 col-md-4">
+						<a href="https://www.canada.ca/en.html">
+						<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="">
+							<span class="wb-inv"> Government of Canada / 
+								<span lang="fr">Gouvernement du Canada</span>
+							</span>
+						</a>
+					</div>
+					<section id="wb-srch" class="col-lg-8 text-right">
+						<h2>Search</h2>
+						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+							<div class="form-group">
+								<label for="wb-srch-q" class="wb-inv">Search website</label>
+								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
+								<input name="st" value="s" type="hidden"/>
+								<input name="num" value="10" type="hidden"/>
+								<input name="langs" value="eng" type="hidden"/>
+								<input name="st1rt" value="0" type="hidden">
+								<input name="s5bm3ts21rch" value="x" type="hidden"/>
+								<datalist id="wb-srch-q-ac">
+									<!--[if lte IE 9]><select><![endif]-->
+									<!--[if lte IE 9]></select><![endif]-->
+								</datalist>
+							</div>
+							<div class="form-group submit">
+								<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+									<span class="glyphicon-search glyphicon"></span>
+									<span class="wb-inv">Search</span>
+								</button>
+							</div>
+						</form>
+					</section>
+				</div>
+			</div>
+			<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+				<div class="container">
+					<h2 class="wb-inv">Menu</h2>
+					<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">
+						<span class="wb-inv">Main </span>Menu 
+						<span class="expicon glyphicon glyphicon-chevron-down"></span>
+					</button>
+					<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a>
+						</li>
+					</ul>
+				</div>
+			</nav>
+			<nav id="wb-bc" property="breadcrumb">
+				<h2>You are here:</h2>
+				<div class="container">
+					<ol class="breadcrumb">
+						<li>
+							<a href='https://www.canada.ca/en.html'>Home</a>
+						</li>
+						<li>
+							<a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a>
+						</li>
+						<li>
+							<a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a>
+						</li>
+						<li>
+							<a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a>
+						</li>
+						<li>
+							<a href='https://design.canada.ca/recommended-templates/transparency.html'>Transparency and corporate reporting</a>
+						</li>
+					</ol>
+				</div>
+			</nav>
+		</header>
+		<!--/* Hide Nav; Hide Right Rail /*-->
+		<main role="main" property="mainContentOfPage" class="container">
+			<p><a class="btn btn-primary" href="./transparency_guidance.html">See guidance</a>  <a class="btn btn-default" href="../recommended-templates/transparency.html">Back to main template page</a></p>
+			<h1 property="name" id="wb-cont">Transparency: [Institution]</h1>
+			<p class="pagetag">Proactive disclosure of information, made public so that Canadians and Parliament are better able to hold the Government and public sector officials to account.</p>
+			<section>
+				<div class="row wb-eqht mrgn-bttm-md">
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Mandate letter from the Prime Minister</a></h2>
+							<p>Commitments and top priorities identified by the government</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Departmental Plan</a></h2>
+							<p>Performance goals for the coming fiscal year</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Departmental Results Report</a></h2>
+							<p>Performance targets met for the 2017-18 fiscal year</p>
+						</section>
+					</div>
+					<div class="clearfix"></div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Travel and hospitality expenses</a></h2>
+							<p>Disclosure of expenditures on Travel, Hospitality and Conferences</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Government contracts awarded</a></h2>
+							<p>Disclosure of contracts over $10,000</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Grants and contributions</a></h2>
+							<p>Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government</p>
+						</section>
+					</div>
+					<div class="clearfix"></div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Disclosure of serious wrongdoing in the workplace</a></h2>
+							<p>Disclosure of wrongdoing found to have been committed</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Reclassification of public service positions</a></h2>
+							<p>Disclosure of government positions that have been reclassified.</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Quarterly Financial Reports</a></h2>
+							<p>Quarterly spending at a departmental level</p>
+						</section>
+					</div>
+					<div class="clearfix"></div>
+						<div class="col-md-4">
+							<section class="gc-drmt">
+								<h2 class="h4"><a href="#">Audits and evaluations</a></h2>
+								<p>Annual reports of audit and evaluations for programs and services at [institution]</p>
+							</section>
+						</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Consultations</a></h2>
+							<p>Public consultations and reports on completed consultations</p>
+						</section>
+					</div>
+					<div class="col-md-4">
+						<section class="gc-drmt">
+							<h2 class="h4"><a href="#">Briefing documents</a></h2>
+							<p>Briefing notes prepared for the President, Secretary and senior managers</p>
+						</section>
+					</div>
+				</div>
 			</section>
-<section>
-<h2 id="navigation">User navigation</h2>
-<p>The user navigation for institutional profiles includes topics, services, program descriptions, reports and other publications, and corporate information.</p>
-<figure class="mrgn-bttm-lg">
-	<figcaption class="text-center"><b>User navigation diagram</b></figcaption>
-	<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-pages-ia-eng.png" class="img-responsive center-block" alt="Diagram of how to navigate to institutional profile pages on Canada.ca. Text version below:">
-	<details>
-		<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
-		<p>Institutional profiles pages can be accessed from the Canada.ca departments and agencies page and topic pages.</p>
-	</details>
-</figure>
-</section>-->
-
-
-
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-        <div class="col-sm-3 mrgn-tp-sm pull-right">
-        <div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-    </div>
-
-
-    <div class="datemod col-xs-12 mrgn-tp-lg">
-        <dl id="wb-dtmd">
-    <dt>Date modified:</dt>
-    <dd><time property="dateModified">2018-09-19</time></dd>
-</dl>
-    </div>
-
-</div>
-    </main>
-
-
-
-
-
-
-
-
-
+			<section>
+				<div class="container">
+					<div class="row mrgn-bttm-lg">
+						<section class="mrgn-bttm-lg">
+							<h2>Didn’t find what you were looking for</h2>
+							<p>Make an access to information or personal information request (ATIP request)</p>
+							<ul class="list-unstyled">
+								<li class="pull-left mrgn-rght-lg">
+									<a class="btn btn-primary" href="#">Make an ATIP request</a>
+								</li>
+								<li class="pull-left mrgn-tp-sm">
+									<a href="https://open.canada.ca/en/search/ati">Completed requests</a>
+								</li>
+							</ul>
+						</section>
+					</div>
+				</div>
+			</section>
+			<div class="row pagedetails">
+				<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+					<div class="panel-pane pane-block pane-bean-report-problem-button"  >
+						<div class="pane-content">
+							<section>
+								<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+									<div class="field-items">
+										<div class="field-item even">
+											<a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a>
+										</div>
+									</div>
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
+				<div class="col-sm-3 mrgn-tp-sm pull-right">
+					<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+				</div>
+				<div class="datemod col-xs-12 mrgn-tp-lg">
+					<dl id="wb-dtmd">
+						<dt>Date modified:</dt>
+						<dd>
+							<time property="dateModified">2018-09-19</time>
+						</dd>
+					</dl>
+				</div>
+			</div>
+		</main>
 		<footer id="wb-info">
-	<div class="landscape">
-	<nav class="container wb-navcurr">
-	<h2 class="wb-inv">About government</h2>
-	<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-	<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
-	<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
-	<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
-	<li><a href="https://www.canada.ca/en/news.html">News</a></li>
-	<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
-	<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
-	<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
-	<li><a href="https://open.canada.ca/en/">Open government</a></li>
-	</ul>
-	</nav>
-	</div>
-	<div class="brand">
-	<div class="container">
-	<div class="row">
-	<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-	<h2 class="wb-inv">About this site</h2>
-	<ul>
-	<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
-	<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
-	<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
-	</ul>
-	</nav>
-	<div class="col-xs-6 visible-sm visible-xs tofpg">
-	<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
-	</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
-	</div>
-	</div>
-	</div>
-	</div>
-	</footer>
-	<!--[if gte IE 9 | !IE ]><!-->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<!--<![endif]-->
-	<!--[if lt IE 9]>
-			<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
-
-			<![endif]-->
-	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
-</body>
-	</html>
+			<div class="landscape">
+				<nav class="container wb-navcurr">
+					<h2 class="wb-inv">About government</h2>
+					<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+						<li>
+							<a href="https://www.canada.ca/en/contact.html">Contact us</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/news.html">News</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
+						</li>
+						<li>
+							<a href="https://pm.gc.ca/eng">Prime Minister</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/system.html">How government works</a>
+						</li>
+						<li>
+							<a href="https://open.canada.ca/en/">Open government</a>
+						</li>
+					</ul>
+				</nav>
+			</div>
+			<div class="brand">
+				<div class="container">
+					<div class="row">
+						<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+							<h2 class="wb-inv">About this site</h2>
+							<ul>
+								<li>
+									<a href="https://www.canada.ca/en/social.html">Social media</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/mobile.html">Mobile applications</a>
+								</li>
+								<li>
+									<a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
+								</li>
+							</ul>
+						</nav>
+						<div class="col-xs-6 visible-sm visible-xs tofpg">
+							<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+						</div>
+						<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+							<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+						</div>
+					</div>
+				</div>
+			</div>
+			</footer>
+			<!--[if gte IE 9 | !IE ]><!-->
+			<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+			<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+			<!--<![endif]-->
+			<!--[if lt IE 9]>
+					<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
+					<![endif]-->
+			<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+			<script>
+			document.getElementById('submissionPage').value = location.href;
+		</script>
+	</body>
+</html>

--- a/mandatory-templates/institutional-profile-pages-3.html
+++ b/mandatory-templates/institutional-profile-pages-3.html
@@ -1,252 +1,231 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
 <!--<![endif]-->
+
 <head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+	<meta charset="utf-8">
+	<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-		<title>Institutional landing page - Canada.ca mandatory template - Canada.ca</title>
+	<title>Institutional landing page - Canada.ca mandatory template - Canada.ca</title>
 
-<meta content="width=device-width,initial-scale=1" name="viewport">
+	<meta content="width=device-width,initial-scale=1" name="viewport">
 
-<!--[if gte IE 9 | !IE ]><!-->
-<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
-<link rel="stylesheet" href="../css/ip.css">
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+	<!--[if gte IE 9 | !IE ]><!-->
+	<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+	<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css">
+	<link rel="stylesheet" href="../css/custom.css">
+	<link rel="stylesheet" href="../css/ip.css">
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
 
-<!--<![endif]-->
-<!--[if lt IE 9]>
+	<!--<![endif]-->
+	<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
 
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
+	<!--[if lte IE 9]>
 
 
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+	<noscript>
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
 
 
- <!-- Global site tag (gtag.js) - Google Analytics -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
 
-<script>
+	<script>
 
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-
-  gtag('config', 'UA-105628416-2');
-
-</script>
-</head>
-<body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-cont">Skip to main content</a>
-</li>
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Language selection</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-<li><a lang="fr" href="https://conception.canada.ca/modeles-obligatoire/pages-profil-institutionnel.html">Français</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-<h2>Search</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
-
-<div class="form-group">
-
-<label for="wb-srch-q" class="wb-inv">Search website</label>
-
-<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
-
-<input name="st" value="s" type="hidden"/>
-
-<input name="num" value="10" type="hidden"/>
-
-<input name="langs" value="eng" type="hidden"/>
-
-<input name="st1rt" value="0" type="hidden">
-
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
-
-<datalist id="wb-srch-q-ac">
-
-<!--[if lte IE 9]><select><![endif]-->
-
-<!--[if lte IE 9]></select><![endif]-->
-
-</datalist>
-
-</div>
-
-<div class="form-group submit">
-
-<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
-
-</div>
-
-</form>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
 
 
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>You are here:</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/en.html'>Home</a></li>
-	<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
-<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
-	<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
-</ol>
-</div>
-</nav>
-</header>
+		gtag('config', 'UA-105628416-2');
 
-<style> /* to move later */
+	</script>
+	<style>
+		/* to move later */
 
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
+		/* added to detail summaries inside the code to remove the bottom spacing */
+		.pattern-demo-code-ex details {
+			margin-bottom: 0px !important;
+		}
 
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
+		.pattern-demo-code-ex .featured {
+			margin-left: .07em !important;
+			margin-right: .07em !important;
+		}
 
-/* .pattern-demo-code-ex .gc-prtts {
+		/* .pattern-demo-code-ex .gc-prtts {
 	width: 99%;
 } */
 
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
+		.pattern-demo {
+			padding: 0px !important;
+			margin: 0px !important;
+			border: none !important;
+		}
 
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
+		.pattern-demo-code-ex {
+			margin-left: -35px !important;
+			margin-right: -35px !important;
+		}
 
-.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
-	background-color: white;
-}
-@media (min-width: 1200px) {
-	.pattern-demo-ex .container {
-	   width: 1100px;
-	}
-}
+		.guidance-details details,
+		.guidance-details summary,
+		.guidance-details details summary:focus,
+		.guidance-details details summary:hover {
+			background-color: white;
+		}
 
-</style>
-<!--/* Hide Nav; Hide Right Rail /*-->
+		@media (min-width: 1200px) {
+			.pattern-demo-ex .container {
+				width: 1100px;
+			}
+		}
+	</style>
+</head>
 
-<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
+<body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
+	<ul id="wb-tphp">
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-cont">Skip to main content</a>
+		</li>
+		<li class="wb-slc">
+			<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
+		</li>
+	</ul>
+	<header>
+		<div id="wb-bnr" class="container">
+			<section id="wb-lng" class="text-right">
+				<h2 class="wb-inv">Language selection</h2>
+				<div class="row">
+					<div class="col-md-12">
+						<ul class="list-inline margin-bottom-none">
+							<li><a lang="fr" href="https://conception.canada.ca/modeles-obligatoire/pages-profil-institutionnel.html">Français</a></li>
+						</ul>
+					</div>
+				</div>
+			</section>
+			<div class="row">
+				<div class="brand col-xs-5 col-md-4">
+					<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
+				</div>
+				<section id="wb-srch" class="col-lg-8 text-right">
+					<h2>Search</h2>
+					<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+						<div class="form-group">
+							<label for="wb-srch-q" class="wb-inv">Search website</label>
+							<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
+							<input name="st" value="s" type="hidden" />
+							<input name="num" value="10" type="hidden" />
+							<input name="langs" value="eng" type="hidden" />
+							<input name="st1rt" value="0" type="hidden">
+							<input name="s5bm3ts21rch" value="x" type="hidden" />
+							<datalist id="wb-srch-q-ac">
+								<!--[if lte IE 9]><select><![endif]-->
+								<!--[if lte IE 9]></select><![endif]-->
+							</datalist>
+						</div>
+						<div class="form-group submit">
+							<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
+						</div>
+					</form>
+				</section>
+			</div>
+		</div>
+		<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+			<div class="container">
+				<h2 class="wb-inv">Menu</h2>
+				<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
+				<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
+					<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
+				</ul>
+			</div>
+		</nav>
+		<nav id="wb-bc" property="breadcrumb">
+			<h2>You are here:</h2>
+			<div class="container">
+				<ol class="breadcrumb">
+					<li><a href='https://www.canada.ca/en.html'>Home</a></li>
+					<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
+					<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
+					<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
+				</ol>
+			</div>
+		</nav>
+	</header>
 
-	<h1 property="name" id="wb-cont" dir="ltr">Institutional landing page - Canada.ca mandatory template</h1>
-
-	<section>
-		<p class="gc-byline"><strong>From: <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a></strong></p>
-
+	<!--/* Hide Nav; Hide Right Rail /*-->
+	<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
+		<h1 property="name" id="wb-cont" dir="ltr">Institutional landing page - Canada.ca mandatory template</h1>
 		<section>
-			<p><span class="label label-danger">Mandatory</span></p>
-			<p>Use this template as the landing page for Government of Canada institutions and organizations.</p>
-			<p>The purpose of this page is to enable people to find information and services offered by that institution, with a focus on top tasks.</p>
-			<p>It should also allow people to find all the other content owned by that institution, including:</p>
-			<ul>
-				<li>mandate and organizational structure</li>
-				<li>contact information</li>
-				<li>news and promotions</li>
-				<li>reports and publications</li>
-			</ul>
-		</section>
-
-		<section>
-			<h2>On this page</h2>
-			<ul>
-				<li><a href="#use">When to use</a></li>
-				<li><a href="#avoid">What to avoid</a></li>
-				<li><a href="#specifications">How to implement</a></li>
-				<li><a href="#research">Research</a></li>
-				<li><a href="#changes">Latest changes</a></li>
-				<li><a href="#discuss">Discussion</a></li>
-			</ul>
-		</section>
-
-		<section>
-			<h2 id="use">When to use</h2>
-			<p>All Government of Canada institutions and organizations subject to the <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=30682"><cite>Directive on the  Management of Communications</cite></a> must use this template as their single home page.
-			<p>Consult the <a href="https://www.canada.ca/en/government/about/design-system/institutions-list.html">Canada.ca Institutions list</a> for the full list.</p>
-		</section>
-
-		<section>
-			<h2 id="avoid">What to avoid</h2>
-			<p>Only use this template as the landing page of official institutions and organizations from the <a href="https://www.canada.ca/en/government/about/design-system/institutions-list.html">Canada.ca Institutions list</a>.</p>
-			<p>Don't use this template for specific programs or entities that are not official institutions or organizations of the Government of Canada.</p>
-		</section>
-
-		<section>
-			<h2 id="specifications">How to implement</h2>
-		</section>
-
-		<section>
-			<p>You can use either the <strong>beta</strong> or the <strong>stable</strong> version of this template.</p>
-
+			<p class="gc-byline"><strong>From: <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a></strong></p>
 			<section>
-				<h3>Beta institutional landing page</h3>
-				<p>The beta version is an improvement over the stable version. It may still be subject to minor changes.</p>
-				<p>The beta version will eventually replace the stable version.</p>
-				<p>You will need to apply custom CSS to use this beta version.</p>
-
-				<div class="row mrgn-tp-lg mrgn-bttm-lg">
-					<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
+				<p><span class="label label-danger">Mandatory</span></p>
+				<p>Use this template as the landing page for Government of Canada institutions and organizations.</p>
+				<p>The purpose of this page is to enable people to find information and services offered by that institution, with a focus on top tasks.</p>
+				<p>It should also allow people to find all the other content owned by that institution, including:</p>
+				<ul>
+					<li>mandate and organizational structure</li>
+					<li>contact information</li>
+					<li>news and promotions</li>
+					<li>reports and publications</li>
+				</ul>
+			</section>
+			<section>
+				<h2>On this page</h2>
+				<ul>
+					<li><a href="#use">When to use</a></li>
+					<li><a href="#avoid">What to avoid</a></li>
+					<li><a href="#specifications">How to implement</a></li>
+					<li><a href="#research">Research</a></li>
+					<li><a href="#changes">Latest changes</a></li>
+					<li><a href="#discuss">Discussion</a></li>
+				</ul>
+			</section>
+			<section>
+				<h2 id="use">When to use</h2>
+				<p>All Government of Canada institutions and organizations subject to the <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=30682"><cite>Directive on the Management of Communications</cite></a> must use this template as their single home page.
+					<p>Consult the <a href="https://www.canada.ca/en/government/about/design-system/institutions-list.html">Canada.ca Institutions list</a> for the full list.</p>
+			</section>
+			<section>
+				<h2 id="avoid">What to avoid</h2>
+				<p>Only use this template as the landing page of official institutions and organizations from the <a href="https://www.canada.ca/en/government/about/design-system/institutions-list.html">Canada.ca Institutions list</a>.</p>
+				<p>Don't use this template for specific programs or entities that are not official institutions or organizations of the Government of Canada.</p>
+			</section>
+			<section>
+				<h2 id="specifications">How to implement</h2>
+			</section>
+			<section>
+				<p>You can use either the <strong>beta</strong> or the <strong>stable</strong> version of this template.</p>
+				<section>
+					<h3>Beta institutional landing page</h3>
+					<p>The beta version is an improvement over the stable version. It may still be subject to minor changes.</p>
+					<p>The beta version will eventually replace the stable version.</p>
+					<p>You will need to apply custom CSS to use this beta version.</p>
+					<div class="row mrgn-tp-lg mrgn-bttm-lg">
+						<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
 							<div class="gc-dwnld">
 								<div class="row">
 									<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
@@ -255,24 +234,20 @@
 									<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
 										<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Beta institutional landing page</span></p>
 										<p><a class="btn btn-call-to-action" href="../coded-layout/institutional_landing_page_guidance.html">Template with guidance</a></p>
-										<!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
-										<!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
 									</div>
 								</div><!-- .row -->
 							</div><!-- .well gc-dwnld -->
-					</div><!-- .col-sm-8 -->
-				</div>
-
-					<!-- </div> <!-- end col-lg-12 -->
-					<!-- <div class="clearfix"></div> -->
-					<!-- <div class="col-lg-12"> -->
+						</div><!-- .col-sm-8 -->
+					</div>
 					<details>
 						<summary>Code</summary>
 						<div class="wb-tabs">
 							<div class="tabpanels">
 								<details id="details-panel1">
 									<summary>HTML</summary>
-									<pre><code>&#x3C;div class=&#x22;ip-cover-img&#x22;&#x3E;
+									<pre>
+										<code>
+&#x3C;div class=&#x22;ip-cover-img&#x22;&#x3E;
  &#x3C;div class=&#x22;container&#x22;&#x3E;
   &#x3C;div class=&#x22;col-lg-7 col-md-7 row&#x22;&#x3E;
    &#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;[Institution name]&#x3C;/h1&#x3E;
@@ -503,33 +478,37 @@
    &#x3C;/div&#x3E;
   &#x3C;/section&#x3E;
  &#x3C;/div&#x3E;
-&#x3C;/div&#x3E;</code></pre>
+&#x3C;/div&#x3E;
+										</code>
+									</pre>
 								</details>
 								<details id="details-panel2">
 									<summary>CSS</summary>
-									<pre><code>.ip-cover-img {
-&#x9;background-image: url(&#x22;https://test.canada.ca/experimental/working-on/images/ip-cover-image.jpg&#x22;);
-&#x9;background-repeat: no-repeat;
-&#x9;background-size: cover;
-&#x9;background-position: right;
-&#x9;margin-top: 15px;
-&#x9;padding-bottom: 25px;
+									<pre>
+										<code>
+.ip-cover-img {
+    background-image: url(&#x22;https://test.canada.ca/experimental/working-on/images/ip-cover-image.jpg&#x22;);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: right;
+    margin-top: 15px;
+    padding-bottom: 25px;
 }
 
 .most-requested li {
-&#x9;font-family: &#x27;Lato&#x27;, sans-serif;
-&#x9;font-size: 17px;
-&#x9;font-weight: 600;
-&#x9;line-height: 26px;
-&#x9;margin-top: 0
+    font-family: &#x27;Lato&#x27;, sans-serif;
+    font-size: 17px;
+    font-weight: 600;
+    line-height: 26px;
+    margin-top: 0
 }
 
 .most-requested h2 {
-&#x9;font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 .ip-btn {
-&#x9;font-size: 1em;
+    font-size: 1em;
 }
 
 /* supports the 3 column layout for MR instead of 4 columns */
@@ -554,763 +533,738 @@
 }
 
 .followus {
-&#x9;background-color: #f5f5f5;
+    background-color: #f5f5f5;
 }
 
 .followus ul li a {
-&#x9;border: solid 2px #f5f5f5;
+    border: solid 2px #f5f5f5;
 }
 
 .featured {
-  margin-bottom: 0em;
-&#x9;padding-top:20px;
-  padding-bottom:20px;
-&#x9;background: #31708f;
+    margin-bottom: 0em;
+    padding-top:20px;
+    padding-bottom:20px;
+    background: #31708f;
 }
 
 .featured a {
-&#x9;color:#fff
+    color:#fff
 }
 
 ul.feeds-cont li a {
-&#x9;font-weight: bold;
+    font-weight: bold;
 }
-
 
 @media screen and (max-width: 1200px) {
   .featured {
-  &#x9;padding-left:.8em;
-&#x9;}
+      padding-left:.8em;
+  }
 }
 
 @media screen and (min-width: 1200px) {
-.list-responsive-3 &#x3E; li {
-    width: 33%;
-&#x9;}
+  .list-responsive-3 &#x3E; li {
+      width: 33%;
+  }
 }
 
 @media screen and (max-width: 767px) {
-
-.btn-call-to-action {
-&#x9;font-size: 19px !important;
-&#x9;}
-
-.most-requested li {
-&#x9;font-size: 19px;
-&#x9;}
-
-.list-responsive-3 &#x3E; li {
-        clear: right;
-        width: 100%
+  .btn-call-to-action {
+    font-size: 19px !important;
   }
 
-.mobile-left {
-&#x9;float: left !important;
-&#x9;}
+  .most-requested li {
+    font-size: 19px;
+  }
 
-.ip-cover-hide-mobile {
-&#x9;&#x9;background-image: url(&#x22;none&#x22;) !important;
+  .list-responsive-3 &#x3E; li {
+    clear: right;
+    width: 100%
+  }
+
+  .mobile-left {
+	float: left !important;
+  }
+
+  .ip-cover-hide-mobile {
+    background-image: url(&#x22;none&#x22;) !important;
+  }
 }
-
-}</code></pre>
+										</code>
+									</pre>
 								</details>
 							</div>
 						</div>
 					</details>
 				</section>
-					<!-- </div> -->
+				<!-- </div> -->
 
-
-			<div class="clearfix"></div>
-			<section>
-				<h3>Stable institutional landing page</h3>
-				<p>The beta version will eventually replace this stable version.</p>
-				<details>
-	        <summary>Guidance for the stable institutional landing page</summary>
-	        <h3 id="profile">Profile page</h3>
-	        <div class="btn-group mrgn-bttm-sm">
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
-	        </div>
-	        <div class="row">
-	          <div class="col-lg-6 pull-right">
-	            <figure class="mrgn-bttm-lg">
-	              <figcaption class="text-center"><b>Profile page template</b></figcaption>
-	              <img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-eng.jpg" class="full-width" alt="Template of institutional profile page for large institutions showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below."> </figure>
-	          </div>
-	          <div class="col-lg-6 pull-left">
-	            <section id="template-elements">
-	              <section>
-	                <h4>1: Institution name</h4>
-	                <p><span class="label label-danger">Mandatory</span></p>
-	                <p>Provides the applied title of the institution</p>
-	                <ul class="list-unstyled">
-	                  <li id="element1">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>use the applied title of the institution, as specified in the <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-eng.asp">Registry of Applied Titles</a></li>
-	                        <li>use the legal title if the applied title is not available</li>
-	                        <li>do not use acronyms or abbreviations</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element2">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li> institutional profile title must be a unique H1</li>
-	                        <li> must be the first component on the page</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>2a: Insignia</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Provides identification of the Royal Canadian Mounted Police</p>
-	                <ul class="list-unstyled">
-	                  <li id="element3">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this component is only allowed for the Royal Canadian Mounted Police, to display their primary approved insignia</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element4">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>the insignia appears to the right of the institutional mandate</li>
-	                        <li>the image is not hyperlinked</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>3: Institutional mandate</h4>
-	                <p><span class="label label-danger">Mandatory</span></p>
-	                <p>Provides 1 or 2 sentences that describe the institution’s mandate</p>
-	                <ul class="list-unstyled">
-	                  <li id="element5">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li> lists the applied title of the institution followed by a brief, plain language overview of how the institution serves the public</li>
-	                        <li>keep the text short and concise</li>
-	                        <li> written for a grade 6-8 reading level</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element6">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>the institutional mandate appears directly below the institutional profile page title</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>4: Institutional social media channels</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Features institution-specific social media channels</p>
-	                <ul class="list-unstyled">
-	                  <li id="element7">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this component is mandatory for all institutions listed under <a href="http://laws-lois.justice.gc.ca/eng/acts/f-11/page-30.html#h-74">Schedule I of the FAA</a>; otherwise, it is optional</li>
-	                        <li>use the <a href="./multi-p-ds-patterns-channels.html">Social media channels block (follow box)</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element8">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears to the right of the institutional mandate</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>5: Latest news</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Features current news items related to the institution</p>
-	                <ul class="list-unstyled">
-	                  <li id="element9">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this component is mandatory for all institutions listed under <a href="http://laws-lois.justice.gc.ca/eng/acts/f-11/page-30.html#h-74">Schedule I of the FAA</a>; otherwise, it is optional</li>
-	                        <li>use the <a href="./multi-p-ds-patterns-latest.html">Latest news</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element10">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below “Institutional social media channels”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>6: Services and information</h4>
-	                <p><span class="label label-danger">Mandatory</span></p>
-	                <p>Lists the institution-specific topics or top tasks</p>
-	                <ul class="list-unstyled">
-	                  <li id="element11">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>use the <a href="./multi-p-ds-patterns-doormat.html">Link and description</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element12">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below the social media channels and to the left of “Most requested”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>7: Most requested</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Features institution-specific top tasks</p>
-	                <ul class="list-unstyled">
-	                  <li id="element13">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this  component in mandatory to provide shortcuts to the institution's top tasks.  However, it should not be used if all of the institution's top tasks are  already included as direct links under Services and information.</li>
-	                        <li>use the <a href="./multi-p-ds-patterns-most_requested.html">Most requested</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element14">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears to the right of “Services and information”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>8: Contact us</h4>
-	                <p><span class="label label-danger">Mandatory</span></p>
-	                <p>Provides access to institutional contact information</p>
-	                <ul class="list-unstyled">
-	                  <li id="element15">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>go to <a href="../common-design-patterns/contact-information.html">Contact information</a> - use either the contact address pattern or contact links pattern</li></ul></details>
-	                  </li>
-	                  <li id="element16">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below “Latest news” and to the right of “Services and information”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>9: More information for</h4>
-	                <p><span class="label label-info">Optional</span></p>
-	                <p>Links to related audience information</p>
-	                <ul class="list-unstyled">
-	                  <li id="element17">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>use the <a href="./multi-p-ds-patterns-more_info_for.html">More information for</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element18">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below “Most requested”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>10: What we are doing</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Provides links to the institution’s program and policy development content</p>
-	                <ul class="list-unstyled">
-	                  <li id="element19">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this component is mandatory when the institution has program and  policy development content to present </li>
-	                        <li>use the <a href="./multi-p-ds-patterns-wwad.html">What we are doing</a> pattern</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element20">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below “Services and information”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>11: Corporate information</h4>
-	                <p><span class="label label-danger">Mandatory</span></p>
-	                <p>Provides consistent access to key corporate information</p>
-	                <ul class="list-unstyled">
-	                  <li id="element21">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>consists of a series of links to institution-specific content not presented elsewhere on the page</li>
-	                        <li>heading is labelled “Corporate information”</li>
-	                        <li>only the “Mandate” and “Transparency” links are mandatory; all other links are optional</li>
-	                        <li>links must be labelled and ordered as follows:
-	                          <dl class="dl-horizontal">
-	                            <dt><strong>Mandate</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li> mandatory</li>
-	                                <li>links to a page providing the institution’s mandate, vision and objectives</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Programs</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li>optional</li>
-	                                <li> links to a page providing the institution’s list of programs</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Organizational structure</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li>optional</li>
-	                                <li> links to a page providing the institution’s organizational chart or structure</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Portfolio</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li>optional</li>
-	                                <li> links to a page providing the institution’s ministerial portfolio</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Partners</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li>optional</li>
-	                                <li>links to a page providing the institution’s existing formal partnerships (for  example,  federal/provincial/territorial, international or non-governmental organizations)</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Transparency</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li>mandatory</li>
-	                                <li>links to institution-specific transparency information prescribed by the Treasury Board of Canada Secretariat, such as forward regulatory plans and proactive disclosure</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Job opportunities</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li> optional</li>
-	                                <li>links to a landing page for institution-specific job opportunities</li>
-	                              </ul>
-	                            </dd>
-	                            <dt><strong>Service performance reporting</strong></dt>
-	                            <dd>
-	                              <ul>
-	                                <li> mandatory, if content exists (see <a href="../recommended-templates/institutional-service-performance-reporting-pages.html">Institutional service performance reporting pages</a>)</li>
-	                                <li> links to a landing page for institution-specific service performance reporting</li>
-	                              </ul>
-	                            </dd>
-	                          </dl>
-	                        </li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element22">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears above “Features”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>12a: Minister of a department or head of a quasi-judicial arm’s-length institution</h4>
-	                <p><span class="label label-warning">Conditional</span></p>
-	                <p>Provides a single profile for each <abbr title="Government of Canada">GC</abbr> minister or institutional head</p>
-	                <ul class="list-unstyled">
-	                  <li id="element23">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>this component is mandatory for all institutions, unless you are using the portfolio ministers component (12b)</li>
-	                        <li> includes hyperlinked images of either an institution’s minister(s), including associate minister(s), or its institutional head (in the case of arm’s-length or quasi-judicial institutions).
-	                          <ul>
-	                            <li>no other individuals may be displayed on the institutional profile</li>
-	                          </ul>
-	                        </li>
-	                        <li>images and texts are hyperlinked to the appropriate ministerial profile page (see <a href="../mandatory-templates/ministerial-profile-pages.html">Ministerial profile pages</a>)</li>
-	                        <li>the hyperlink text is limited to the minister’s or institutional head’s honorific (“The Honourable”) and first and last name</li>
-	                        <li>non-hyperlinked text is limited to the minister’s or institutional head’s official title</li>
-	                        <li>the following headings must be presented above the appropriate elected official:
-	                          <ul>
-	                            <li>“Minister”</li>
-	                            <li>“Parliamentary secretary”</li>
-	                            <li>“Associate minister”</li>
-	                          </ul>
-	                        </li>
-	                        <li>the heading of “Management” or “Ombudsman”, must be presented, as appropriate, above the senior-most public servant who is the institutional head</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element24">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears to the right of “Corporate information”</li>
-	                        <li>priority sequencing is from left to right</li>
-	                        <li>when more than 3 images are required, continue the list on a second row</li>
-	                        <li>when fewer than 3 images are required, the image must be left-aligned to the corporate information block</li>
-	                        <li>go to the <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-en.html">Canada.ca GitHub page</a> for image sizing details</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	              <section>
-	                <h4>13: Institution features</h4>
-	                <p><span class="label label-info">Optional</span></p>
-	                <p>Promotes institution-specific current activities being led by the institution</p>
-	                <ul class="list-unstyled">
-	                  <li id="element25">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>use the <a href="./multi-p-ds-components-features.html">Context-specific features</a> component</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element26">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>heading is labelled “Features”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	            </section>
-	          </div>
-	        </div>
-	        <section>
-	          <h3 id="branding">How to use the arms-length branding</h3>
-	          <div class="btn-group mrgn-bttm-sm">
-	            <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
-	            <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
-	          </div>
-	          <div class="row">
-	            <div class="col-lg-6 pull-right">
-	              <figure class="mrgn-bttm-lg">
-	                <figcaption class="text-center"><b>Arm’s length branding example</b></figcaption>
-	                <img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/arms-length-branding-eng.jpg" class="full-width" alt="Image of arm’s-length identification showing components that make up its structure. Read top to bottom and left to right. Specifications detailed below."> </figure>
-	            </div>
-	            <div class="col-lg-6 pull-left">
-	              <section id="template-elements2">
-	                <section>
-	                  <h4>2b: Arm’s-length branding</h4>
-	                  <p><span class="label label-warning">Conditional</span></p>
-	                  <p>Displays approved identifier for institutions that meet the criteria for Arm’s Length</p>
-	                  <ul class="list-unstyled">
-	                    <li id="element2-1">
-	                      <details class="mrgn-bttm-sm">
-	                        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                        <ul>
-	                          <li>this component is conditional. Only institutions categorized as administrative tribunals under the <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=eng">rules for Governor in Council appointments</a> have the option to display their approved brand identification</li>
-	                          <li>institutions categorized as agencies or boards that have a core mandate to make binding decisions or rulings may also have the option to display their approved, primary brand identification, as determined on a case-by-case basis by central agencies</li>
-	                          <li>the branding must follow the Federal Identity Program (FIP) rules for identifying federal institutions</li>
-	                        </ul>
-	                      </details>
-	                    </li>
-	                    <li id="element2-2">
-	                      <details class="mrgn-bttm-sm">
-	                        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                        <ul>
-	                          <li>the arm’s-length branding appears at the top of the page</li>
-	                          <li>the image must be formatted according to FIP design specifications, where applicable (i.e. for institutions not exempt from FIP)</li>
-	                          <li>the image must be configured to scale automatically to screen size (SVG is the recommended format), in line with responsive web design</li>
-	                          <li>the image is not hyperlinked</li>
-	                        </ul>
-	                      </details>
-	                    </li>
-	                  </ul>
-	                </section>
-	                <section>
-	                  <h4>3a: Arm’s-length statement</h4>
-	                  <p><span class="label label-warning">Conditional</span></p>
-	                  <p>Explains the arm’s-length nature of the institution</p>
-	                  <ul class="list-unstyled">
-	                    <li id="element2-3">
-	                      <details class="mrgn-bttm-sm">
-	                        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                        <ul>
-	                          <li>this component is conditional. Only institutions categorized as administrative tribunals under the <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=eng">rules for Governor in Council appointments</a> have the option to include the arm’s length statement</li>
-	                          <li>institutions categorized as agencies or boards that have a core mandate to make binding decisions or rulings may also have the option to include this statement, as determined on a case-by-case basis by central agencies</li>
-	                          <li>the statement gives a concise explanation of the autonomous nature of the arm’s-length institution</li>
-	                        </ul>
-	                      </details>
-	                    </li>
-	                    <li id="element2-4">
-	                      <details class="mrgn-bttm-sm">
-	                        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                        <ul>
-	                          <li>it is presented in boldface</li>
-	                        </ul>
-	                      </details>
-	                    </li>
-	                  </ul>
-	                </section>
-	              </section>
-	            </div>
-	          </div>
-	          </section>
-	        <section>
-	        <h3 id="ministers">How to use the portfolio ministers pattern</h3>
-	        <div class="btn-group mrgn-bttm-sm">
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
-	        </div>
-	        <div class="row">
-	          <div class="col-lg-6 pull-right">
-	            <figure class="mrgn-bttm-lg">
-	              <figcaption class="text-center"><b>Portfolio ministers example</b></figcaption>
-	              <img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-ministers-component-eng.jpg" class="full-width" alt="Image of portfolio ministers component showing elements that make up its structure. Read top to bottom and left to right. Specifications detailed below."> </figure>
-	          </div>
-	          <div class="col-lg-6 pull-left">
-	            <section id="template-elements3">
-	              <section>
-	                <h4>12b: Portfolio ministers</h4>
-	                <p><span class="label label-info">Optional</span></p>
-	                <p>Provides access to the profiles of all portfolio ministers under the institution’s portfolio</p>
-	                <ul class="list-unstyled">
-	                  <li id="element3-1">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li>must not be used when a minister or institutional head is listed under “Corporate information” (see 12a)</li>
-	                        <li>can only be used when 3 or more ministers are presented</li>
-	                        <li>it provides hyperlinked images of an institution’s minister(s)
-	                          <ul>
-	                            <li>no other individuals can be displayed on the institutional profile</li>
-	                          </ul>
-	                        </li>
-	                        <li>images and texts are hyperlinked to the appropriate ministerial profile page (see <a href="../mandatory-templates/ministerial-profile-pages.html">Ministerial profile pages</a>)</li>
-	                        <li>hyperlink text is limited to minister’s honorific, first and last name only: Honourable [name of minister]</li>
-	                        <li>non-hyperlinked text is limited to the minister’s official title</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element3-2">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears above “Corporate information”</li>
-	                        <li>priority sequencing is from left to right</li>
-	                        <li>when more than 3 images are required, continue the list on a second row</li>
-	                        <li>go to the <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-en.html">Canada.ca GitHub page</a> for image sizing details</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	            </section>
-	          </div>
-	        </div>
-	        </section>
-	        <section>
-	        <h3 id="organizations">How to use the portfolio organizations pattern</h3>
-	        <div class="btn-group mrgn-bttm-sm">
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
-	          <button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
-	        </div>
-	        <div class="row">
-	          <div class="col-lg-6 pull-right">
-	            <figure class="mrgn-bttm-lg">
-	              <figcaption class="text-center"><b>Portfolio organizations example</b></figcaption>
-	              <img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-organizations-component-eng.jpg" class="full-width" alt="Image of portfolio organizations component showing elements that make up its structure. Read top to bottom and left to right. Specifications detailed below."> </figure>
-	          </div>
-	          <div class="col-lg-6 pull-left">
-	            <section id="template-elements4">
-	              <section>
-	                <h4>14: Portfolio organizations</h4>
-	                <p><span class="label label-info">Optional</span></p>
-	                <p>Provides navigation to portfolio organizations within the institution</p>
-	                <ul class="list-unstyled">
-	                  <li id="element4-1">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
-	                      <ul>
-	                        <li> lists all portfolio organizations under an institution</li>
-	                        <li> heading is labelled “Portfolio organizations”</li>
-	                        <li> links must be directed to an organizational profile page (see <a href="../mandatory-templates/organizational-profile-pages.html">Organizational profile pages</a>)</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                  <li id="element4-2">
-	                    <details class="mrgn-bttm-sm">
-	                      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
-	                      <ul>
-	                        <li>appears below “What we are doing”</li>
-	                      </ul>
-	                    </details>
-	                  </li>
-	                </ul>
-	              </section>
-	            </section>
-	          </div>
-	        </div>
-	        </section>
-	      </details>
+				<div class="clearfix"></div>
+				<section>
+					<h3>Stable institutional landing page</h3>
+					<p>The beta version will eventually replace this stable version.</p>
+					<details>
+						<summary>Guidance for the stable institutional landing page</summary>
+						<h3 id="profile">Profile page</h3>
+						<div class="btn-group mrgn-bttm-sm">
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
+							<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
+						</div>
+						<div class="row">
+							<div class="col-lg-6 pull-right">
+								<figure class="mrgn-bttm-lg">
+									<figcaption class="text-center"><b>Profile page template</b></figcaption>
+									<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-eng.jpg" class="full-width" alt="Template of institutional profile page for large institutions showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below.">
+								</figure>
+							</div>
+							<div class="col-lg-6 pull-left">
+								<section id="template-elements">
+									<section>
+										<h4>1: Institution name</h4>
+										<p><span class="label label-danger">Mandatory</span></p>
+										<p>Provides the applied title of the institution</p>
+										<ul class="list-unstyled">
+											<li id="element1">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>use the applied title of the institution, as specified in the <a href="https://www.tbs-sct.gc.ca/hgw-cgf/oversight-surveillance/communications/fip-pcim/reg-eng.asp">Registry of Applied Titles</a></li>
+														<li>use the legal title if the applied title is not available</li>
+														<li>do not use acronyms or abbreviations</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element2">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li> institutional profile title must be a unique H1</li>
+														<li> must be the first component on the page</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>2a: Insignia</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Provides identification of the Royal Canadian Mounted Police</p>
+										<ul class="list-unstyled">
+											<li id="element3">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component is only allowed for the Royal Canadian Mounted Police, to display their primary approved insignia</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element4">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>the insignia appears to the right of the institutional mandate</li>
+														<li>the image is not hyperlinked</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>3: Institutional mandate</h4>
+										<p><span class="label label-danger">Mandatory</span></p>
+										<p>Provides 1 or 2 sentences that describe the institution’s mandate</p>
+										<ul class="list-unstyled">
+											<li id="element5">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li> lists the applied title of the institution followed by a brief, plain language overview of how the institution serves the public</li>
+														<li>keep the text short and concise</li>
+														<li> written for a grade 6-8 reading level</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element6">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>the institutional mandate appears directly below the institutional profile page title</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>4: Institutional social media channels</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Features institution-specific social media channels</p>
+										<ul class="list-unstyled">
+											<li id="element7">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component is mandatory for all institutions listed under <a href="http://laws-lois.justice.gc.ca/eng/acts/f-11/page-30.html#h-74">Schedule I of the FAA</a>; otherwise, it is optional</li>
+														<li>use the <a href="./multi-p-ds-patterns-channels.html">Social media channels block (follow box)</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element8">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears to the right of the institutional mandate</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>5: Latest news</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Features current news items related to the institution</p>
+										<ul class="list-unstyled">
+											<li id="element9">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component is mandatory for all institutions listed under <a href="http://laws-lois.justice.gc.ca/eng/acts/f-11/page-30.html#h-74">Schedule I of the FAA</a>; otherwise, it is optional</li>
+														<li>use the <a href="./multi-p-ds-patterns-latest.html">Latest news</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element10">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears below “Institutional social media channels”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>6: Services and information</h4>
+										<p><span class="label label-danger">Mandatory</span></p>
+										<p>Lists the institution-specific topics or top tasks</p>
+										<ul class="list-unstyled">
+											<li id="element11">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>use the <a href="./multi-p-ds-patterns-doormat.html">Link and description</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element12">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears below the social media channels and to the left of “Most requested”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>7: Most requested</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Features institution-specific top tasks</p>
+										<ul class="list-unstyled">
+											<li id="element13">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component in mandatory to provide shortcuts to the institution's top tasks. However, it should not be used if all of the institution's top tasks are already included as direct links under Services and information.</li>
+														<li>use the <a href="./multi-p-ds-patterns-most_requested.html">Most requested</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element14">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears to the right of “Services and information”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>8: Contact us</h4>
+										<p><span class="label label-danger">Mandatory</span></p>
+										<p>Provides access to institutional contact information</p>
+										<ul class="list-unstyled">
+											<li id="element15">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>go to <a href="../common-design-patterns/contact-information.html">Contact information</a> - use either the contact address pattern or contact links pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element16">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears below “Latest news” and to the right of “Services and information”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>9: More information for</h4>
+										<p><span class="label label-info">Optional</span></p>
+										<p>Links to related audience information</p>
+										<ul class="list-unstyled">
+											<li id="element17">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>use the <a href="./multi-p-ds-patterns-more_info_for.html">More information for</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element18">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears below “Most requested”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>10: What we are doing</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Provides links to the institution’s program and policy development content</p>
+										<ul class="list-unstyled">
+											<li id="element19">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component is mandatory when the institution has program and policy development content to present </li>
+														<li>use the <a href="./multi-p-ds-patterns-wwad.html">What we are doing</a> pattern</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element20">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears below “Services and information”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>11: Corporate information</h4>
+										<p><span class="label label-danger">Mandatory</span></p>
+										<p>Provides consistent access to key corporate information</p>
+										<ul class="list-unstyled">
+											<li id="element21">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>consists of a series of links to institution-specific content not presented elsewhere on the page</li>
+														<li>heading is labelled “Corporate information”</li>
+														<li>only the “Mandate” and “Transparency” links are mandatory; all other links are optional</li>
+														<li>links must be labelled and ordered as follows:
+															<dl class="dl-horizontal">
+																<dt><strong>Mandate</strong></dt>
+																<dd>
+																	<ul>
+																		<li> mandatory</li>
+																		<li>links to a page providing the institution’s mandate, vision and objectives</li>
+																	</ul>
+																</dd>
+																<dt><strong>Programs</strong></dt>
+																<dd>
+																	<ul>
+																		<li>optional</li>
+																		<li> links to a page providing the institution’s list of programs</li>
+																	</ul>
+																</dd>
+																<dt><strong>Organizational structure</strong></dt>
+																<dd>
+																	<ul>
+																		<li>optional</li>
+																		<li> links to a page providing the institution’s organizational chart or structure</li>
+																	</ul>
+																</dd>
+																<dt><strong>Portfolio</strong></dt>
+																<dd>
+																	<ul>
+																		<li>optional</li>
+																		<li> links to a page providing the institution’s ministerial portfolio</li>
+																	</ul>
+																</dd>
+																<dt><strong>Partners</strong></dt>
+																<dd>
+																	<ul>
+																		<li>optional</li>
+																		<li>links to a page providing the institution’s existing formal partnerships (for example, federal/provincial/territorial, international or non-governmental organizations)</li>
+																	</ul>
+																</dd>
+																<dt><strong>Transparency</strong></dt>
+																<dd>
+																	<ul>
+																		<li>mandatory</li>
+																		<li>links to institution-specific transparency information prescribed by the Treasury Board of Canada Secretariat, such as forward regulatory plans and proactive disclosure</li>
+																	</ul>
+																</dd>
+																<dt><strong>Job opportunities</strong></dt>
+																<dd>
+																	<ul>
+																		<li> optional</li>
+																		<li>links to a landing page for institution-specific job opportunities</li>
+																	</ul>
+																</dd>
+																<dt><strong>Service performance reporting</strong></dt>
+																<dd>
+																	<ul>
+																		<li> mandatory, if content exists (see <a href="../recommended-templates/institutional-service-performance-reporting-pages.html">Institutional service performance reporting pages</a>)</li>
+																		<li> links to a landing page for institution-specific service performance reporting</li>
+																	</ul>
+																</dd>
+															</dl>
+														</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element22">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears above “Features”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>12a: Minister of a department or head of a quasi-judicial arm’s-length institution</h4>
+										<p><span class="label label-warning">Conditional</span></p>
+										<p>Provides a single profile for each <abbr title="Government of Canada">GC</abbr> minister or institutional head</p>
+										<ul class="list-unstyled">
+											<li id="element23">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>this component is mandatory for all institutions, unless you are using the portfolio ministers component (12b)</li>
+														<li> includes hyperlinked images of either an institution’s minister(s), including associate minister(s), or its institutional head (in the case of arm’s-length or quasi-judicial institutions).
+															<ul>
+																<li>no other individuals may be displayed on the institutional profile</li>
+															</ul>
+														</li>
+														<li>images and texts are hyperlinked to the appropriate ministerial profile page (see <a href="../mandatory-templates/ministerial-profile-pages.html">Ministerial profile pages</a>)</li>
+														<li>the hyperlink text is limited to the minister’s or institutional head’s honorific (“The Honourable”) and first and last name</li>
+														<li>non-hyperlinked text is limited to the minister’s or institutional head’s official title</li>
+														<li>the following headings must be presented above the appropriate elected official:
+															<ul>
+																<li>“Minister”</li>
+																<li>“Parliamentary secretary”</li>
+																<li>“Associate minister”</li>
+															</ul>
+														</li>
+														<li>the heading of “Management” or “Ombudsman”, must be presented, as appropriate, above the senior-most public servant who is the institutional head</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element24">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>appears to the right of “Corporate information”</li>
+														<li>priority sequencing is from left to right</li>
+														<li>when more than 3 images are required, continue the list on a second row</li>
+														<li>when fewer than 3 images are required, the image must be left-aligned to the corporate information block</li>
+														<li>go to the <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-en.html">Canada.ca GitHub page</a> for image sizing details</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+									<section>
+										<h4>13: Institution features</h4>
+										<p><span class="label label-info">Optional</span></p>
+										<p>Promotes institution-specific current activities being led by the institution</p>
+										<ul class="list-unstyled">
+											<li id="element25">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+													<ul>
+														<li>use the <a href="./multi-p-ds-components-features.html">Context-specific features</a> component</li>
+													</ul>
+												</details>
+											</li>
+											<li id="element26">
+												<details class="mrgn-bttm-sm">
+													<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+													<ul>
+														<li>heading is labelled “Features”</li>
+													</ul>
+												</details>
+											</li>
+										</ul>
+									</section>
+								</section>
+							</div>
+						</div>
+						<section>
+							<h3 id="branding">How to use the arms-length branding</h3>
+							<div class="btn-group mrgn-bttm-sm">
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements2&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
+							</div>
+							<div class="row">
+								<div class="col-lg-6 pull-right">
+									<figure class="mrgn-bttm-lg">
+										<figcaption class="text-center"><b>Arm’s length branding example</b></figcaption>
+										<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/arms-length-branding-eng.jpg" class="full-width" alt="Image of arm’s-length identification showing components that make up its structure. Read top to bottom and left to right. Specifications detailed below.">
+									</figure>
+								</div>
+								<div class="col-lg-6 pull-left">
+									<section id="template-elements2">
+										<section>
+											<h4>2b: Arm’s-length branding</h4>
+											<p><span class="label label-warning">Conditional</span></p>
+											<p>Displays approved identifier for institutions that meet the criteria for Arm’s Length</p>
+											<ul class="list-unstyled">
+												<li id="element2-1">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+														<ul>
+															<li>this component is conditional. Only institutions categorized as administrative tribunals under the <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=eng">rules for Governor in Council appointments</a> have the option to display their approved brand identification</li>
+															<li>institutions categorized as agencies or boards that have a core mandate to make binding decisions or rulings may also have the option to display their approved, primary brand identification, as determined on a case-by-case basis by central agencies</li>
+															<li>the branding must follow the Federal Identity Program (FIP) rules for identifying federal institutions</li>
+														</ul>
+													</details>
+												</li>
+												<li id="element2-2">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+														<ul>
+															<li>the arm’s-length branding appears at the top of the page</li>
+															<li>the image must be formatted according to FIP design specifications, where applicable (i.e. for institutions not exempt from FIP)</li>
+															<li>the image must be configured to scale automatically to screen size (SVG is the recommended format), in line with responsive web design</li>
+															<li>the image is not hyperlinked</li>
+														</ul>
+													</details>
+												</li>
+											</ul>
+										</section>
+										<section>
+											<h4>3a: Arm’s-length statement</h4>
+											<p><span class="label label-warning">Conditional</span></p>
+											<p>Explains the arm’s-length nature of the institution</p>
+											<ul class="list-unstyled">
+												<li id="element2-3">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+														<ul>
+															<li>this component is conditional. Only institutions categorized as administrative tribunals under the <a href="http://www.appointments-nominations.gc.ca/prsnt.asp?menu=2&amp;page=gicIntro&amp;lang=eng">rules for Governor in Council appointments</a> have the option to include the arm’s length statement</li>
+															<li>institutions categorized as agencies or boards that have a core mandate to make binding decisions or rulings may also have the option to include this statement, as determined on a case-by-case basis by central agencies</li>
+															<li>the statement gives a concise explanation of the autonomous nature of the arm’s-length institution</li>
+														</ul>
+													</details>
+												</li>
+												<li id="element2-4">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+														<ul>
+															<li>it is presented in boldface</li>
+														</ul>
+													</details>
+												</li>
+											</ul>
+										</section>
+									</section>
+								</div>
+							</div>
+						</section>
+						<section>
+							<h3 id="ministers">How to use the portfolio ministers pattern</h3>
+							<div class="btn-group mrgn-bttm-sm">
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements3&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
+							</div>
+							<div class="row">
+								<div class="col-lg-6 pull-right">
+									<figure class="mrgn-bttm-lg">
+										<figcaption class="text-center"><b>Portfolio ministers example</b></figcaption>
+										<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-ministers-component-eng.jpg" class="full-width" alt="Image of portfolio ministers component showing elements that make up its structure. Read top to bottom and left to right. Specifications detailed below.">
+									</figure>
+								</div>
+								<div class="col-lg-6 pull-left">
+									<section id="template-elements3">
+										<section>
+											<h4>12b: Portfolio ministers</h4>
+											<p><span class="label label-info">Optional</span></p>
+											<p>Provides access to the profiles of all portfolio ministers under the institution’s portfolio</p>
+											<ul class="list-unstyled">
+												<li id="element3-1">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+														<ul>
+															<li>must not be used when a minister or institutional head is listed under “Corporate information” (see 12a)</li>
+															<li>can only be used when 3 or more ministers are presented</li>
+															<li>it provides hyperlinked images of an institution’s minister(s)
+																<ul>
+																	<li>no other individuals can be displayed on the institutional profile</li>
+																</ul>
+															</li>
+															<li>images and texts are hyperlinked to the appropriate ministerial profile page (see <a href="../mandatory-templates/ministerial-profile-pages.html">Ministerial profile pages</a>)</li>
+															<li>hyperlink text is limited to minister’s honorific, first and last name only: Honourable [name of minister]</li>
+															<li>non-hyperlinked text is limited to the minister’s official title</li>
+														</ul>
+													</details>
+												</li>
+												<li id="element3-2">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+														<ul>
+															<li>appears above “Corporate information”</li>
+															<li>priority sequencing is from left to right</li>
+															<li>when more than 3 images are required, continue the list on a second row</li>
+															<li>go to the <a href="http://wet-boew.github.io/themes-dist/GCWeb/index-en.html">Canada.ca GitHub page</a> for image sizing details</li>
+														</ul>
+													</details>
+												</li>
+											</ul>
+										</section>
+									</section>
+								</div>
+							</div>
+						</section>
+						<section>
+							<h3 id="organizations">How to use the portfolio organizations pattern</h3>
+							<div class="btn-group mrgn-bttm-sm">
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;on&quot;}">Expand All</button>
+								<button type="button" class="btn btn-default wb-toggle" data-toggle="{&quot;selector&quot;: &quot;details&quot;, &quot;parent&quot;: &quot;#template-elements4&quot;, &quot;type&quot;: &quot;off&quot;}">Collapse All</button>
+							</div>
+							<div class="row">
+								<div class="col-lg-6 pull-right">
+									<figure class="mrgn-bttm-lg">
+										<figcaption class="text-center"><b>Portfolio organizations example</b></figcaption>
+										<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/portfolio-organizations-component-eng.jpg" class="full-width" alt="Image of portfolio organizations component showing elements that make up its structure. Read top to bottom and left to right. Specifications detailed below.">
+									</figure>
+								</div>
+								<div class="col-lg-6 pull-left">
+									<section id="template-elements4">
+										<section>
+											<h4>14: Portfolio organizations</h4>
+											<p><span class="label label-info">Optional</span></p>
+											<p>Provides navigation to portfolio organizations within the institution</p>
+											<ul class="list-unstyled">
+												<li id="element4-1">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Content</strong></summary>
+														<ul>
+															<li> lists all portfolio organizations under an institution</li>
+															<li> heading is labelled “Portfolio organizations”</li>
+															<li> links must be directed to an organizational profile page (see <a href="../mandatory-templates/organizational-profile-pages.html">Organizational profile pages</a>)</li>
+														</ul>
+													</details>
+												</li>
+												<li id="element4-2">
+													<details class="mrgn-bttm-sm">
+														<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}"><strong>Presentation</strong></summary>
+														<ul>
+															<li>appears below “What we are doing”</li>
+														</ul>
+													</details>
+												</li>
+											</ul>
+										</section>
+									</section>
+								</div>
+							</div>
+						</section>
+					</details>
+				</section>
 			</section>
-		</section>
 
-		<h2 id="research">Research</h2>
+			<h2 id="research">Research</h2>
 			<p>We succesfully tested the new beta institutional landing page during 2 optimization projects with the Canada Revenue Agency.</p>
-<p><a href="https://blog.canada.ca/research-summaries/cra-contact-us-research-summary.html">Research summary: Contact the CRA</a></p>
-		<section>
-			<h2 id="changes">Latest changes</h2>
-			<p><strong>2019-11-21:</strong> a new beta version of this template was added</p>
+			<p><a href="https://blog.canada.ca/research-summaries/cra-contact-us-research-summary.html">Research summary: Contact the CRA</a></p>
+			<section>
+				<h2 id="changes">Latest changes</h2>
+				<p><strong>2019-11-21:</strong> a new beta version of this template was added</p>
 
-		</section>
-		<section>
-			<h2 id="discuss">Discussion</h2>
-			<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the template in github issues</a></p>
-		</section>
-			<!--<section>
-				<h2 id="examples">Working examples</h2>
-				<ul>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-en.html">English working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-fr.html">French working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-en.html">English working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-fr.html">French working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-				</ul>
 			</section>
-<section>
-<h2 id="navigation">User navigation</h2>
-<p>The user navigation for institutional profiles includes topics, services, program descriptions, reports and other publications, and corporate information.</p>
-<figure class="mrgn-bttm-lg">
-	<figcaption class="text-center"><b>User navigation diagram</b></figcaption>
-	<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-pages-ia-eng.png" class="img-responsive center-block" alt="Diagram of how to navigate to institutional profile pages on Canada.ca. Text version below:">
-	<details>
-		<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
-		<p>Institutional profiles pages can be accessed from the Canada.ca departments and agencies page and topic pages.</p>
-	</details>
-</figure>
-</section>-->
+			<section>
+				<h2 id="discuss">Discussion</h2>
+				<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the template in github issues</a></p>
+			</section>
 
+			<div class="row pagedetails">
+				<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+					<div class="panel-pane pane-block pane-bean-report-problem-button">
+						<div class="pane-content">
+							<section>
+								<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+									<div class="field-items">
+										<div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div>
+									</div>
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
 
+				<div class="col-sm-3 mrgn-tp-sm pull-right">
+					<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+				</div>
 
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-        <div class="col-sm-3 mrgn-tp-sm pull-right">
-        <div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-    </div>
-
-
-    <div class="datemod col-xs-12 mrgn-tp-lg">
-        <dl id="wb-dtmd">
-    <dt>Date modified:</dt>
-    <dd><time property="dateModified">2018-09-19</time></dd>
-</dl>
-    </div>
-
-</div>
-    </main>
-
-
-
-
-
-
-
-
-
-		<footer id="wb-info">
-	<div class="landscape">
-	<nav class="container wb-navcurr">
-	<h2 class="wb-inv">About government</h2>
-	<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-	<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
-	<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
-	<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
-	<li><a href="https://www.canada.ca/en/news.html">News</a></li>
-	<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
-	<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
-	<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
-	<li><a href="https://open.canada.ca/en/">Open government</a></li>
-	</ul>
-	</nav>
-	</div>
-	<div class="brand">
-	<div class="container">
-	<div class="row">
-	<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-	<h2 class="wb-inv">About this site</h2>
-	<ul>
-	<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
-	<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
-	<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
-	</ul>
-	</nav>
-	<div class="col-xs-6 visible-sm visible-xs tofpg">
-	<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
-	</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
-	</div>
-	</div>
-	</div>
-	</div>
+				<div class="datemod col-xs-12 mrgn-tp-lg">
+					<dl id="wb-dtmd">
+						<dt>Date modified:</dt>
+						<dd><time property="dateModified">2018-09-19</time></dd>
+					</dl>
+				</div>
+			</div>
+	</main>
+	<footer id="wb-info">
+		<div class="landscape">
+			<nav class="container wb-navcurr">
+				<h2 class="wb-inv">About government</h2>
+				<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+					<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
+					<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
+					<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
+					<li><a href="https://www.canada.ca/en/news.html">News</a></li>
+					<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
+					<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
+					<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
+					<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
+					<li><a href="https://open.canada.ca/en/">Open government</a></li>
+				</ul>
+			</nav>
+		</div>
+		<div class="brand">
+			<div class="container">
+				<div class="row">
+					<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+						<h2 class="wb-inv">About this site</h2>
+						<ul>
+							<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
+							<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
+							<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
+							<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
+							<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
+						</ul>
+					</nav>
+					<div class="col-xs-6 visible-sm visible-xs tofpg">
+						<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+					</div>
+					<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+						<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+					</div>
+				</div>
+			</div>
+		</div>
 	</footer>
 	<!--[if gte IE 9 | !IE ]><!-->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
@@ -1322,7 +1276,8 @@ ul.feeds-cont li a {
 			<![endif]-->
 	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
 	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
+		document.getElementById('submissionPage').value = location.href;
+	</script>
 </body>
-	</html>
+
+</html>

--- a/recommended-templates/transparency.html
+++ b/recommended-templates/transparency.html
@@ -1,467 +1,453 @@
-
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
 <html class="no-js" lang="en" dir="ltr">
-<!--<![endif]-->
-<head>
-<meta charset="utf-8">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+	<!--<![endif]-->
+	<head>
+		<meta charset="utf-8">
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+				wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>Transparency and corporate reporting - Canada.ca recommended template - Canada.ca</title>
-
-<meta content="width=device-width,initial-scale=1" name="viewport">
-
-<!--[if gte IE 9 | !IE ]><!-->
-<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
-<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
-<link rel="stylesheet" href="../css/ip.css">
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
-
-<!--<![endif]-->
-<!--[if lt IE 9]>
+		<meta content="width=device-width,initial-scale=1" name="viewport">
+		<!--[if gte IE 9 | !IE ]><!-->
+		<link href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" rel="icon" type="image/x-icon">
+		<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/css/theme.min.css"><link rel="stylesheet" href="../css/custom.css">
+		<link rel="stylesheet" href="../css/ip.css">
+		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
+		<!--<![endif]-->
+		<!--[if lt IE 9]>
 		<link href="./GCWeb/assets/favicon.ico" rel="shortcut icon" />
-
 		<link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/ie8-theme.min.css" />
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 		<script src="./wet-boew/js/ie8-wet-boew.min.js"></script>
 		<![endif]-->
-<!--[if lte IE 9]>
-
-
+		<!--[if lte IE 9]>
 		<![endif]-->
-<noscript><link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" /></noscript>
+		<noscript>
+			<link rel="stylesheet" href="https://www.canada.ca/etc/designs/canada/wet-boew/wet-boew/css/noscript.min.css" />
+		</noscript>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'UA-105628416-2');            
+		</script>
+		<style> /* to move later */
+			/* added to detail summaries inside the code to remove the bottom spacing */
+			.pattern-demo-code-ex details {
+				margin-bottom: 0px !important;
+			}
 
+			.pattern-demo-code-ex .featured {
+				margin-left: .07em !important;
+				margin-right: .07em !important;
+			}
 
- <!-- Global site tag (gtag.js) - Google Analytics -->
+			.pattern-demo {
+				padding: 0px !important;
+				margin: 0px !important;
+				border: none !important;
+			}
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-105628416-2"></script>
+			.pattern-demo-code-ex {
+				margin-left: -35px !important;
+				margin-right: -35px !important;
+			}
 
-<script>
-
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-
-  gtag('config', 'UA-105628416-2');
-
-</script>
-</head>
-<body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
-<ul id="wb-tphp">
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-cont">Skip to main content</a>
-</li>
-<li class="wb-slc">
-<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
-</li>
-</ul>
-<header>
-<div id="wb-bnr" class="container">
-<section id="wb-lng" class="text-right">
-<h2 class="wb-inv">Language selection</h2>
-<div class="row">
-<div class="col-md-12">
-<ul class="list-inline margin-bottom-none">
-<li><a lang="fr" href="https://conception.canada.ca/modeles-recommandes/transparence.html">Français</a></li>
-</ul>
-</div>
-</div>
-</section>
-<div class="row">
-<div class="brand col-xs-5 col-md-4">
-<a href="https://www.canada.ca/en.html"><img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt=""><span class="wb-inv"> Government of Canada / <span lang="fr">Gouvernement du Canada</span></span></a>
-</div>
-<section id="wb-srch" class="col-lg-8 text-right">
-<h2>Search</h2>
-<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
-
-<div class="form-group">
-
-<label for="wb-srch-q" class="wb-inv">Search website</label>
-
-<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
-
-<input name="st" value="s" type="hidden"/>
-
-<input name="num" value="10" type="hidden"/>
-
-<input name="langs" value="eng" type="hidden"/>
-
-<input name="st1rt" value="0" type="hidden">
-
-<input name="s5bm3ts21rch" value="x" type="hidden"/>
-
-<datalist id="wb-srch-q-ac">
-
-<!--[if lte IE 9]><select><![endif]-->
-
-<!--[if lte IE 9]></select><![endif]-->
-
-</datalist>
-
-</div>
-
-<div class="form-group submit">
-
-<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub"><span class="glyphicon-search glyphicon"></span><span class="wb-inv">Search</span></button>
-
-</div>
-
-</form>
-
-
-</section>
-</div>
-</div>
-<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
-<div class="container">
-<h2 class="wb-inv">Menu</h2>
-<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false"><span class="wb-inv">Main </span>Menu <span class="expicon glyphicon glyphicon-chevron-down"></span></button>
-<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a></li>
-	<li role="none presentation"><a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a></li>
-</ul>
-</div>
-</nav>
-<nav id="wb-bc" property="breadcrumb">
-<h2>You are here:</h2>
-<div class="container">
-<ol class="breadcrumb">
-	<li><a href='https://www.canada.ca/en.html'>Home</a></li>
-	<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
-<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
-	<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
-</ol>
-</div>
-</nav>
-</header>
-
-<style> /* to move later */
-
-/* added to detail summaries inside the code to remove the bottom spacing */
-.pattern-demo-code-ex details {
-	margin-bottom: 0px !important;
-}
-
-.pattern-demo-code-ex .featured {
-	margin-left: .07em !important;
-	margin-right: .07em !important;
-}
-
-/* .pattern-demo-code-ex .gc-prtts {
-	width: 99%;
-} */
-
-.pattern-demo {
-	padding: 0px !important;
-	margin: 0px !important;
-	border: none !important;
-}
-
-.pattern-demo-code-ex {
-	margin-left: -35px !important;
-	margin-right: -35px !important;
-}
-
-.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
-	background-color: white;
-}
-
-</style>
-<!--/* Hide Nav; Hide Right Rail /*-->
-
-<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
-
-	<h1 property="name" id="wb-cont" dir="ltr">Transparency and corporate reporting - Canada.ca recommended template</h1>
-
-	<section>
-		<p class="gc-byline"><strong>From: <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a></strong></p>
-
-		<section>
-			<p>A corporate reporting page provides proactive disclosure of information offered by that institution.</p>
-			<p>The corporate reporting page template:</p>
-			<ul>
-				<li>supports a consistent approach to the presentation of corporate reporting-related information</li>
-				<li>promotes task completion by prioritizing access to tasks related to corporate reporting</li>
-				<li>complements the objectives of the institutional landing pages by offering institution-specific related information on proactive disclosure</li>
-				<li> limits the amount of content used to describe proactive disclosure</li>
-			</ul>
-		</section>
-
-		<section>
-			<h2>On this page</h2>
-			<ul>
-				<li><a href="#use">When to use</a></li>
-				<li><a href="#avoid">What to avoid</a></li>
-				<li><a href="#specifications">How to implement</a></li>
-				<li><a href="#discuss">Discussion</a></li>
-			</ul>
-		</section>
-
-		<section>
-			<h2 id="use">When to use</h2>
-			<p>Use this template as the transparency and corporate reporting landing page for Government of Canada institutions and organizations.</p>
-		</section>
-
-		<section>
-			<h2 id="avoid">What to avoid</h2>
-			<p>Only use this template once per institution.</p>
-		</section>
-
-		<section>
-			<h2 id="specifications">How to implement</h2>
-			<div class="row mrgn-tp-lg mrgn-bttm-lg">
-				<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
-						<div class="gc-dwnld">
-							<div class="row">
-								<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
-									<p><a class="gc-dwnld-lnk" href="../coded-layout/transparency_guidance.html"><img class="thumbnail gc-dwnld-img" src="../images/transparency-cropped.png" alt="" width="110" height="142"></a></p>
-								</div>
-								<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
-									<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Transparency and corporate reporting</span></p>
-									<p><a class="btn btn-call-to-action" href="../coded-layout/transparency_guidance.html">Template with guidance</a></p>
-									<!-- <p class="mrgn-tp-md" style="line-height:3em;"><a class="btn btn-primary mrgn-rght-sm" href="citizenship-test/study-guide.html" role="button">Start studying</a></p> -->
-									<!--<p class="mrgn-tp-lg">or <a class="gc-dwnld-lnk" href="citizenship-test/study-guide.html">download the PDF version</a></p>-->
-								</div>
-							</div><!-- .row -->
-						</div><!-- .well gc-dwnld -->
-				</div><!-- .col-sm-8 -->
+			.guidance-details details, .guidance-details summary, .guidance-details details summary:focus, .guidance-details details summary:hover {
+				background-color: white;
+			}
+		</style>
+	</head>
+	<body class="cnt-wdth-lmtd" vocab="http://schema.org/" typeof="WebPage">
+		<ul id="wb-tphp">
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-cont">Skip to main content</a>
+			</li>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-info">Skip to "About government"</a>
+			</li>
+		</ul>
+		<header>
+			<div id="wb-bnr" class="container">
+				<section id="wb-lng" class="text-right">
+					<h2 class="wb-inv">Language selection</h2>
+					<div class="row">
+						<div class="col-md-12">
+							<ul class="list-inline margin-bottom-none">
+								<li>
+									<a lang="fr" href="https://conception.canada.ca/modeles-recommandes/transparence.html">Français</a>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</section>
+				<div class="row">
+					<div class="brand col-xs-5 col-md-4">
+						<a href="https://www.canada.ca/en.html">
+							<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/sig-blk-en.svg" alt="">
+							<span class="wb-inv"> Government of Canada / 
+								<span lang="fr">Gouvernement du Canada</span>
+							</span>
+						</a>
+					</div>
+					<section id="wb-srch" class="col-lg-8 text-right">
+						<h2>Search</h2>
+						<form action="https://recherche-search.gc.ca/rGs/s_r?#wb-land" method="get" role="search" class="form-inline">
+							<div class="form-group">
+								<label for="wb-srch-q" class="wb-inv">Search website</label>
+								<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="27" maxlength="150" placeholder="Search Canada.ca">
+								<input name="st" value="s" type="hidden"/>
+								<input name="num" value="10" type="hidden"/>
+								<input name="langs" value="eng" type="hidden"/>
+								<input name="st1rt" value="0" type="hidden">
+								<input name="s5bm3ts21rch" value="x" type="hidden"/>
+								<datalist id="wb-srch-q-ac">
+									<!--[if lte IE 9]><select><![endif]-->
+									<!--[if lte IE 9]></select><![endif]-->
+								</datalist>
+							</div>
+							<div class="form-group submit">
+								<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+									<span class="glyphicon-search glyphicon"></span>
+									<span class="wb-inv">Search</span>
+								</button>
+							</div>
+						</form>
+					</section>
+				</div>
 			</div>
-
-
-<details>
-<summary>Code</summary>
-<pre class="prettyprint"><code>&#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;Transparency: [Institution]&#x3C;/h1&#x3E;
+			<nav class="gweb-v2 gcweb-menu" typeof="SiteNavigationElement">
+				<div class="container">
+					<h2 class="wb-inv">Menu</h2>
+					<button type="button" aria-haspopup="true" aria-controls="gc-mnu" aria-expanded="false">
+						<span class="wb-inv">Main </span>Menu 
+						<span class="expicon glyphicon glyphicon-chevron-down"></span>
+					</button>
+					<ul id="gc-mnu" role="menu" aria-orientation="vertical" data-ajax-replace="https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-en.html">
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/jobs.html">Jobs and the workplace</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/immigration-citizenship.html">Immigration and citizenship</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://travel.gc.ca/">Travel and tourism</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/business.html">Business and industry</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/benefits.html">Benefits</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/health.html">Health</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/taxes.html">Taxes</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/environment.html">Environment and natural resources</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/defence.html">National security and defence</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/culture.html">Culture, history and sport</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/policing.html">Policing, justice and emergencies</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/transport.html">Transport and infrastructure</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="http://international.gc.ca/world-monde/index.aspx?lang=eng">Canada and the world</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Money and finances</a>
+						</li>
+						<li role="none presentation">
+							<a role="menuitem" tabindex="-1" href="https://www.canada.ca/en/services/finance.html">Science and innovation</a>
+						</li>
+					</ul>
+				</div>
+			</nav>
+			<nav id="wb-bc" property="breadcrumb">
+				<h2>You are here:</h2>
+				<div class="container">
+					<ol class="breadcrumb">
+						<li><a href='https://www.canada.ca/en.html'>Home</a></li>
+						<li><a href='https://www.canada.ca/en/government/about.html'>About Canada.ca</a></li>
+						<li><a href='https://www.canada.ca/en/government/about/design-system.html'>Canada.ca design system</a></li>
+						<li><a href='https://www.canada.ca/en/government/about/design-system/pattern-library.html'>Template and pattern library for Canada.ca</a></li>
+					</ol>
+				</div>
+			</nav>
+		</header>
+		<!--/* Hide Nav; Hide Right Rail /*-->
+		<main role="main" property="mainContentOfPage" class="container wb-prettify all-pre">
+			<h1 property="name" id="wb-cont" dir="ltr">Transparency and corporate reporting - Canada.ca recommended template</h1>
+			<section>
+				<p class="gc-byline"><strong>From: <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a></strong></p>
+				<section>
+					<p>A corporate reporting page provides proactive disclosure of information offered by that institution.</p>
+					<p>The corporate reporting page template:</p>
+					<ul>
+						<li>supports a consistent approach to the presentation of corporate reporting-related information</li>
+						<li>promotes task completion by prioritizing access to tasks related to corporate reporting</li>
+						<li>complements the objectives of the institutional landing pages by offering institution-specific related information on proactive disclosure</li>
+						<li> limits the amount of content used to describe proactive disclosure</li>
+					</ul>
+				</section>
+				<section>
+					<h2>On this page</h2>
+					<ul>
+						<li><a href="#use">When to use</a></li>
+						<li><a href="#avoid">What to avoid</a></li>
+						<li><a href="#specifications">How to implement</a></li>
+						<li><a href="#discuss">Discussion</a></li>
+					</ul>
+				</section>
+				<section>
+					<h2 id="use">When to use</h2>
+					<p>Use this template as the transparency and corporate reporting landing page for Government of Canada institutions and organizations.</p>
+				</section>
+				<section>
+					<h2 id="avoid">What to avoid</h2>
+					<p>Only use this template once per institution.</p>
+				</section>
+				<section>
+					<h2 id="specifications">How to implement</h2>
+					<div class="row mrgn-tp-lg mrgn-bttm-lg">
+						<div class="col-xs-10 col-sm-10 col-md-8 col-lg-8">
+								<div class="gc-dwnld">
+									<div class="row">
+										<div class="col-xs-10 col-sm-3 col-md-3 col-lg-2">
+											<p><a class="gc-dwnld-lnk" href="../coded-layout/transparency_guidance.html"><img class="thumbnail gc-dwnld-img" src="../images/transparency-cropped.png" alt="" width="110" height="142"></a></p>
+										</div>
+										<div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
+											<p style="font-size:24px;line-height:1em;" class="mrgn-tp-md"><span>Transparency and corporate reporting</span></p>
+											<p><a class="btn btn-call-to-action" href="../coded-layout/transparency_guidance.html">Template with guidance</a></p>
+										</div>
+									</div><!-- .row -->
+								</div><!-- .gc-dwnld -->
+						</div><!-- .col-sm-8 -->
+					</div>
+					<details>
+						<summary>Code</summary>
+						<pre class="prettyprint">
+							<code>
+&#x3C;h1 property=&#x22;name&#x22; id=&#x22;wb-cont&#x22;&#x3E;Transparency: [Institution]&#x3C;/h1&#x3E;
 &#x3C;p class=&#x22;pagetag&#x22;&#x3E;Proactive disclosure of information, made public so that Canadians and Parliament are better able to hold the Government and public sector officials to account.&#x3C;/p&#x3E;
 &#x3C;section&#x3E;
- &#x3C;div class=&#x22;row wb-eqht mrgn-bttm-md&#x22;&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Mandate letter from the Prime Minister&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Commitments and top priorities identified by the government&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Departmental Plan&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Performance goals for the coming fiscal year&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Departmental Results Report&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Performance targets met for the 2017-18 fiscal year&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Travel and hospitality expenses&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Disclosure of expenditures on Travel, Hospitality and Conferences&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Government contracts awarded&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Disclosure of contracts over $10,000&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Grants and contributions&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Disclosure of serious wrongdoing in the workplace&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Disclosure of wrongdoing found to have been committed&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Reclassification of public service positions&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Disclosure of government positions that have been reclassified.&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Quarterly Financial Reports&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Quarterly spending at a departmental level&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Audits and evaluations&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Annual reports of audit and evaluations for programs and services at [institution]&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Consultations&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Public consultations and reports on completed consultations&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
-   &#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
-    &#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Briefing documents&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
-    &#x3C;p&#x3E;Briefing notes prepared for the President, Secretary and senior managers&#x3C;/p&#x3E;
-   &#x3C;/section&#x3E;
-  &#x3C;/div&#x3E;
-  &#x3C;/div&#x3E;
+	&#x3C;div class=&#x22;row wb-eqht mrgn-bttm-md&#x22;&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Mandate letter from the Prime Minister&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Commitments and top priorities identified by the government&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Departmental Plan&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Performance goals for the coming fiscal year&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Departmental Results Report&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Performance targets met for the 2017-18 fiscal year&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Travel and hospitality expenses&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Disclosure of expenditures on Travel, Hospitality and Conferences&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Government contracts awarded&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Disclosure of contracts over $10,000&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Grants and contributions&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Disclosure of transfers of money, goods, services or assets to individuals, organizations or other levels of government&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Disclosure of serious wrongdoing in the workplace&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Disclosure of wrongdoing found to have been committed&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Reclassification of public service positions&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Disclosure of government positions that have been reclassified.&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Quarterly Financial Reports&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Quarterly spending at a departmental level&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;clearfix&#x22;&#x3E;&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Audits and evaluations&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Annual reports of audit and evaluations for programs and services at [institution]&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Consultations&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Public consultations and reports on completed consultations&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+		&#x3C;div class=&#x22;col-md-4&#x22;&#x3E;
+			&#x3C;section class=&#x22;gc-drmt&#x22;&#x3E;
+				&#x3C;h2 class=&#x22;h4&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Briefing documents&#x3C;/a&#x3E;&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Briefing notes prepared for the President, Secretary and senior managers&#x3C;/p&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+	&#x3C;/div&#x3E;
 &#x3C;/section&#x3E;
 &#x3C;section&#x3E;
- &#x3C;div&#x3E;
-  &#x3C;div class=&#x22;row mrgn-bttm-lg&#x22;&#x3E;
-   &#x3C;div class=&#x22;col-md-12&#x22;&#x3E;
-    &#x3C;section class=&#x22;mrgn-bttm-lg&#x22;&#x3E;
-     &#x3C;h2&#x3E;Didn&#x2019;t find what you were looking for&#x3C;/h2&#x3E;
-     &#x3C;p&#x3E;Make an access to information or personal information request (ATIP request)&#x3C;/p&#x3E;
-     &#x3C;ul class=&#x22;list-unstyled&#x22;&#x3E;
-      &#x3C;li class=&#x22;pull-left mrgn-rght-lg&#x22;&#x3E;&#x3C;a class=&#x22;btn btn-primary&#x22; href=&#x22;#&#x22;&#x3E;Make an ATIP request&#x3C;/a&#x3E;&#x3C;/li&#x3E;
-      &#x3C;li class=&#x22;pull-left mrgn-tp-sm&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Completed requests&#x3C;/a&#x3E;&#x3C;/li&#x3E;
-     &#x3C;/ul&#x3E;
-    &#x3C;/section&#x3E;
-   &#x3C;/div&#x3E;
-  &#x3C;/div&#x3E;
- &#x3C;/div&#x3E;
+	&#x3C;div class="container"&#x3E;
+		&#x3C;div class=&#x22;row mrgn-bttm-lg&#x22;&#x3E;
+			&#x3C;section class=&#x22;mrgn-bttm-lg&#x22;&#x3E;
+				&#x3C;h2&#x3E;Didn&#x2019;t find what you were looking for&#x3C;/h2&#x3E;
+				&#x3C;p&#x3E;Make an access to information or personal information request (ATIP request)&#x3C;/p&#x3E;
+				&#x3C;ul class=&#x22;list-unstyled&#x22;&#x3E;
+					&#x3C;li class=&#x22;pull-left mrgn-rght-lg&#x22;&#x3E;&#x3C;a class=&#x22;btn btn-primary&#x22; href=&#x22;#&#x22;&#x3E;Make an ATIP request&#x3C;/a&#x3E;&#x3C;/li&#x3E;
+					&#x3C;li class=&#x22;pull-left mrgn-tp-sm&#x22;&#x3E;&#x3C;a href=&#x22;#&#x22;&#x3E;Completed requests&#x3C;/a&#x3E;&#x3C;/li&#x3E;
+				&#x3C;/ul&#x3E;
+			&#x3C;/section&#x3E;
+		&#x3C;/div&#x3E;
+	&#x3C;/div&#x3E;
 &#x3C;/section&#x3E;
-</code></pre>
-</details>
-
-
-
-
-</section> <!-- end of pattern-demo -->
-</div> <!-- end col-lg-12 -->
-<h2 id="discuss">Discussion</h2>
-<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the template in github issues</a></p>
-</section>
-
-
-			<!--<section>
-				<h2 id="examples">Working examples</h2>
-				<ul>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-en.html">English working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-fr.html">French working example of institutional profile</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-en.html">English working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-					<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/institution-arms-fr.html">French working example of institutional profile for arm’s-length institutions</a> (on GitHub)</li>
-				</ul>
+							</code>
+						</pre>
+					</details>
+				</section> <!-- end of pattern-demo -->
+				<h2 id="discuss">Discussion</h2>
+				<p><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the template in github issues</a></p>
 			</section>
-<section>
-<h2 id="navigation">User navigation</h2>
-<p>The user navigation for institutional profiles includes topics, services, program descriptions, reports and other publications, and corporate information.</p>
-<figure class="mrgn-bttm-lg">
-	<figcaption class="text-center"><b>User navigation diagram</b></figcaption>
-	<img src="https://www.canada.ca/content/dam/tbs-sct/images/government-communications/canada-content-style-guide/institutional-profile-pages-ia-eng.png" class="img-responsive center-block" alt="Diagram of how to navigate to institutional profile pages on Canada.ca. Text version below:">
-	<details>
-		<summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
-		<p>Institutional profiles pages can be accessed from the Canada.ca departments and agencies page and topic pages.</p>
-	</details>
-</figure>
-</section>-->
-
-
-
-<div class="row pagedetails">
-<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
-<div class="panel-pane pane-block pane-bean-report-problem-button"  >
-<div class="pane-content">
-<section>
-<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a></div></div></div></section>
-</div>
-</div>
-</div>
-
-        <div class="col-sm-3 mrgn-tp-sm pull-right">
-        <div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
-    </div>
-
-
-    <div class="datemod col-xs-12 mrgn-tp-lg">
-        <dl id="wb-dtmd">
-    <dt>Date modified:</dt>
-    <dd><time property="dateModified">2018-09-19</time></dd>
-</dl>
-    </div>
-
-</div>
-    </main>
-
-
-
-
-
-
-
-
-
+			<div class="row pagedetails">
+				<div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+					<div class="panel-pane pane-block pane-bean-report-problem-button"  >
+						<div class="pane-content">
+							<section>
+								<div class="field field-name-field-bean-wetkit-body field-type-text-long field-label-hidden">
+									<div class="field-items">
+										<div class="field-item even">
+											<a class="btn btn-default btn-block" href="https://www.canada.ca/en/report-problem.html">Report a problem on this page</a>
+										</div>
+									</div>
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
+				<div class="col-sm-3 mrgn-tp-sm pull-right">
+					<div class="wb-share" data-wb-share='{&#34;lnkClass&#34;: &#34;btn btn-default btn-block&#34;}'></div>
+				</div>
+				<div class="datemod col-xs-12 mrgn-tp-lg">
+					<dl id="wb-dtmd">
+						<dt>Date modified:</dt>
+						<dd>
+							<time property="dateModified">2018-09-19</time>
+						</dd>
+					</dl>
+				</div>
+			</div>
+		</main>
 		<footer id="wb-info">
-	<div class="landscape">
-	<nav class="container wb-navcurr">
-	<h2 class="wb-inv">About government</h2>
-	<ul class="list-unstyled colcount-sm-2 colcount-md-3">
-	<li><a href="https://www.canada.ca/en/contact.html">Contact us</a></li>
-	<li><a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a></li>
-	<li><a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a></li>
-	<li><a href="https://www.canada.ca/en/news.html">News</a></li>
-	<li><a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a></li>
-	<li><a href="https://pm.gc.ca/eng">Prime Minister</a></li>
-	<li><a href="https://www.canada.ca/en/government/system.html">How government works</a></li>
-	<li><a href="https://open.canada.ca/en/">Open government</a></li>
-	</ul>
-	</nav>
-	</div>
-	<div class="brand">
-	<div class="container">
-	<div class="row">
-	<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
-	<h2 class="wb-inv">About this site</h2>
-	<ul>
-	<li><a href="https://www.canada.ca/en/social.html">Social media</a></li>
-	<li><a href="https://www.canada.ca/en/mobile.html">Mobile applications</a></li>
-	<li><a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a></li>
-	<li><a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a></li>
-	</ul>
-	</nav>
-	<div class="col-xs-6 visible-sm visible-xs tofpg">
-	<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
-	</div>
-	<div class="col-xs-6 col-md-3 col-lg-2 text-right">
-	<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
-	</div>
-	</div>
-	</div>
-	</div>
-	</footer>
-	<!--[if gte IE 9 | !IE ]><!-->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
-	<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
-	<!--<![endif]-->
-	<!--[if lt IE 9]>
-			<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
-
-			<![endif]-->
-	<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
-	<script>
-	document.getElementById('submissionPage').value = location.href;
-</script>
-</body>
-	</html>
+			<div class="landscape">
+				<nav class="container wb-navcurr">
+					<h2 class="wb-inv">About government</h2>
+					<ul class="list-unstyled colcount-sm-2 colcount-md-3">
+						<li>
+							<a href="https://www.canada.ca/en/contact.html">Contact us</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/dept.html">Departments and agencies</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/publicservice.html">Public service and military</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/news.html">News</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/system/laws.html">Treaties, laws and regulations</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/transparency/reporting.html">Government-wide reporting</a>
+						</li>
+						<li>
+							<a href="https://pm.gc.ca/eng">Prime Minister</a>
+						</li>
+						<li>
+							<a href="https://www.canada.ca/en/government/system.html">How government works</a>
+						</li>
+						<li>
+							<a href="https://open.canada.ca/en/">Open government</a>
+						</li>
+					</ul>
+				</nav>
+			</div>
+			<div class="brand">
+				<div class="container">
+					<div class="row">
+						<nav class="col-md-9 col-lg-10 ftr-urlt-lnk">
+							<h2 class="wb-inv">About this site</h2>
+							<ul>
+								<li>
+									<a href="https://www.canada.ca/en/social.html">Social media</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/mobile.html">Mobile applications</a>
+								</li>
+								<li>
+									<a href="https://www1.canada.ca/en/newsite.html">About Canada.ca</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/transparency/terms.html">Terms and conditions</a>
+								</li>
+								<li>
+									<a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
+								</li>
+							</ul>
+						</nav>
+						<div class="col-xs-6 visible-sm visible-xs tofpg">
+							<a href="#wb-cont">Top of Page <span class="glyphicon glyphicon-chevron-up"></span></a>
+						</div>
+						<div class="col-xs-6 col-md-3 col-lg-2 text-right">
+							<img src="http://www.canada.ca/etc/designs/canada/wet-boew/assets/wmms-blk.svg" alt="Symbol of the Government of Canada">
+						</div>
+					</div>
+				</div>
+			</div>
+		</footer>
+		<!--[if gte IE 9 | !IE ]><!-->
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.js"></script>
+		<script src="https://wet-boew.github.io/themes-dist/GCWeb/wet-boew/js/wet-boew.min.js"></script>
+		<!--<![endif]-->
+		<!--[if lt IE 9]>
+				<script src="./wet-boew/js/ie8-wet-boew2.min.js"></script>
+				<![endif]-->
+		<script src="https://www.canada.ca/etc/designs/canada/wet-boew/js/theme.min.js"></script>
+		<script>
+			document.getElementById('submissionPage').value = location.href;
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Because:
- Instutional landing pages were using `p` tag in `figure`
- Some grid elements weren't properly nested

Replaced `figure` tag with `div` and `figcaption` for `h3`. Some `.row`
weren't nested in `.container` properly. `.col-md-12` was used as a fix
for the lack of `.container` class.