### PR TITLE
Most requested - Fix broken link to GCWeb

### DIFF
--- a/common-design-patterns/most-requested.html
+++ b/common-design-patterns/most-requested.html
@@ -183,9 +183,15 @@
 </ul>
 </section>
 <section>
+	<h2>Technical documentation</h2>
+	<ul>
+		<li><a href="https://wet-boew.github.io/GCWeb/components/gc-most-requested/gc-most-requested-en.html">GC most requested</a></li>
+	</ul>
+</section>
+<section>
 <h2>Working example</h2>
 <ul>
-	<li><a href="http://wet-boew.github.io/themes-dist/GCWeb/topic-en.html">Topic template</a></li>
+	<li><a href="https://wet-boew.github.io/GCWeb/templates/topic/topic-en.html">Topic template</a></li>
 </ul>
 </section>
 <section class="panel panel-primary">


### PR DESCRIPTION
Fix a broken link to GCWeb in the most requested component.

Some little change is required to GCWeb prior to merge this PR. 
* [ ] Isolate the technical documentation of the most requested component
* [ ] Fix to the most requested include in the GCWeb topic template

Related to: https://github.com/wet-boew/wet-boew/issues/9331

