### PR TITLE
chore: upgrade lockfile to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,18 @@
 {
   "name": "design-system",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "vnu-jar": {
+  "packages": {
+    "": {
+      "name": "design-system",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "vnu-jar": "^23.4.11"
+      }
+    },
+    "node_modules/vnu-jar": {
       "version": "23.4.11",
       "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-23.4.11.tgz",
       "integrity": "sha512-lI5dzBYXtxhilNI7EeQ5iUduYnNBq7YWx4UjfBVLXfBQHnXYZSf3y3bpM0bSyDU6jy/+OyKV7nw4tzpR5lXSZg==",


### PR DESCRIPTION
Since it was created with an old version of NPM, Netlify complains about it when building