### PR TITLE
Update alerts.html

### DIFF
--- a/crisis/alerts.html
+++ b/crisis/alerts.html
@@ -203,10 +203,10 @@
 						<h3>Additional examples</h3>
 						<p>Alert examples on specific page types:</p>
 						<ul>
-							<li><a href="https://design.canada.ca/alerts-alertes/alerts-sit.html">Service initiation page</a></li>
-							<li><a href="https://design.canada.ca/alerts-alertes/alerts-contact.html">Contact page</a></li>
-							<li><a href="https://design.canada.ca/alerts-alertes/alerts-ilp.html">Beta institutional landing page</a></li>
-							<li><a href="https://design.canada.ca/alerts-alertes/alerts-stable-ip.html">Institutional profile</a></li>
+							<li><a href="https://design.canada.ca/alerts/alerts-sit.html">Service initiation page</a></li>
+							<li><a href="https://design.canada.ca/alerts/alerts-contact.html">Contact page</a></li>
+							<li><a href="https://design.canada.ca/alerts/alerts-ilp.html">Beta institutional landing page</a></li>
+							<li><a href="https://design.canada.ca/alerts/alerts-stable-ip.html">Institutional profile</a></li>
 						</ul>
 					</section>
 					<section>


### PR DESCRIPTION
I fixed the four broken links under the heading 'Additional examples'. They simply had an extra '-alertes- in the url which was causing them to return 404 errors. I will also update the links on the French page.