### PR TITLE
Signature.md - correcting other language link

### DIFF
--- a/common-design-patterns/global-header/signature.md
+++ b/common-design-patterns/global-header/signature.md
@@ -1,5 +1,5 @@
 ---
-altLangPage: "https://conception.canada.ca/configurations-conception-communes/fil-ariane.html"
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/signature.html"
 date: 2017-10-05
 dateModified: 2023-06-26
 description: "Guidance about using the Government of Canada signature on Canada.ca. The signature is an official symbol of the Government of Canada. It always appears in the global header across Canada.ca."


### PR DESCRIPTION
Noticed that the language toggle on https://design.canada.ca/common-design-patterns/signature.html was pointing at the wrong file.

So this PR is to correct that.

No parallel French PR needed, as on the french version of this page, the language toggle is functioning as expected.