### PR TITLE
Small changes to signature.md

### DIFF
--- a/common-design-patterns/global-header/signature.md
+++ b/common-design-patterns/global-header/signature.md
@@ -39,7 +39,7 @@ title: "Government of Canada signature"
 <p>Find content and design specifications and visual examples.</p>
 <h3>Content specifications</h3>
   <p>The Government of Canada signature appears in the top-left corner of the page.</p>
-  <p>The signature is composed of the flag symbol in Federal Identity Policy red, followed by the words Government of Canada in English and Gouvernement du Canada in French, both in black text.</p>
+  <p>The signature is composed of the flag symbol in Federal Identity Program red, followed by the words Government of Canada in English and Gouvernement du Canada in French, both in black text.</p>
   <p>The signature must appear as English first on English pages and French first on French pages.</p>
 <h4>Accessibility</h4>
 <p>Include Government of Canada as alt text on the English side, Gouvernement du Canada as alt text on the French side.</p>
@@ -54,7 +54,7 @@ title: "Government of Canada signature"
   <li>Alt text: Government of Canada</li>
 </ul>
 <p>The signature is a Scalable Vector Graphics (SVG) file, configured to scale automatically according to screen size.</p>
-<p>The signature is an image file that must be formatted according to <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard/colour-design-standard-fip.html">Federal Identity Program design specifications</a>.</p>
+<p>The signature is an image file that must be formatted according to the <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard.html">Design Standard for the Federal Identity Program</a>.</p>
 <h3>Visual examples</h3>
 <div class="pattern-demo mrgn-tp-lg">
   <figure>


### PR DESCRIPTION
2 small changes, requested by our CFIPC colleagues:
- under Content specifications, change mention of "Federal Identity Policy" to "Federal Identity Program"
- under Design specifications, link to the main page of the Design Standard for the Federal Identity Program rather than the deeper page we had originally linked to

French PR: [to come](https://github.com/canada-ca/systeme-conception/pull/179)