### PR TITLE
Typo in the page title H1 on usage-canadaca-design.md

### DIFF
--- a/architecture/usage-canadaca-design.md
+++ b/architecture/usage-canadaca-design.md
@@ -4,7 +4,7 @@ date: 2017-10-05
 dateModified: 2023-03-28
 description: "The requirements listed in this design manual apply to departments and other portions of the federal public administration as set out in Schedules I, I.1 and II of the Financial Administration Act. As such, in-scope institutions must apply Canada.ca design requirements for all public-facing web sites or digital services."
 layout: default
-title: "Who has to use the Canada.ca design sytem"
+title: "Who has to use the Canada.ca design system"
 ---
 <p class="gc-byline"><strong>From: <a href="https://www.canada.ca/en/treasury-board-secretariat.html">Treasury Board of Canada Secretariat</a></strong></p>
 <div class="mrgn-tp-md mrgn-bttm-sm brdr-bttm">


### PR DESCRIPTION
fixing a typo in the page title... amazingly there is a similar typo in the FR.

FR pull request: https://github.com/canada-ca/systeme-conception/pull/181

