### PR TITLE
fix:  Create sitesearch.html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@
   "remote_theme": "wet-boew/gcweb-jekyll",
   "themeopt": "Policies",
   "title": "Canada.ca design system",
-  "url": "https://design.canada.ca",
+  "url": "",
   "urlconception": "https://conception.canada.ca",
   "urlcanadaca": "https://www.canada.ca",
   "urlblogca": "https://blog.canada.ca",
@@ -83,6 +83,7 @@
           "https://use.fontawesome.com/releases/v5.15.4/css/all.css",
           "/css/custom.css"
         ],
+        "lang": "en",
         "layout": "default",
         "pageclass": "cnt-wdth-lmtd",
         "script": "/js/gc-pg-hlpfl.js",
@@ -393,7 +394,7 @@
     },
     {
       "scope": {
-        "path": "recommended-template/*.md"
+        "path": "recommended-templates/*.md"
       },
       "values": {
         "breadcrumbs": [{

--- a/_includes/headers-includes/sitesearch.html
+++ b/_includes/headers-includes/sitesearch.html
@@ -1,0 +1,17 @@
+
+<section id="wb-srch" class="col-lg-offset-4 col-md-offset-4 col-sm-offset-2 col-xs-12 col-sm-5 col-md-4">
+	<h2>{{ i18nText-search }}</h2>
+	<form action="https://canada.ca/{{ page.lang }}/sr/srb.html" method="get" name="cse-search-box" role="search">
+		<div class="form-group wb-srch-qry">
+			<label for="wb-srch-q" class="wb-inv">{{ i18nText-searchSite }}</label>
+			<input id="wb-srch-q" list="wb-srch-q-ac" class="wb-srch-q form-control" name="q" type="search" value="" size="34" maxlength="170" placeholder="{{ i18nText-searchSite }}" />
+			<datalist id="wb-srch-q-ac"></datalist>
+		</div>
+		<div class="form-group submit">
+			<button type="submit" id="wb-srch-sub" class="btn btn-primary btn-small" name="wb-srch-sub">
+				<span class="glyphicon-search glyphicon"></span>
+				<span class="wb-inv">{{ i18nText-search }}</span>
+			</button>
+		</div>
+	</form>
+</section>


### PR DESCRIPTION
Implement default Canada.ca search on the design system
Fix _config.yml missing properties for language, redirect and breadcrumbs

## JIRA
- https://canada-style-guide.atlassian.net/browse/DSBT-18?atlOrigin=eyJpIjoiYmE5ZDAxZDQ2YmUyNDk2NWI0MDhiNjA5MGQ5NWY5NGQiLCJwIjoiaiJ9
- https://canada-style-guide.atlassian.net/browse/DSBT-18?atlOrigin=eyJpIjoiYmE5ZDAxZDQ2YmUyNDk2NWI0MDhiNjA5MGQ5NWY5NGQiLCJwIjoiaiJ9

## Alternate language PR
https://github.com/canada-ca/systeme-conception/pull/211