### PR TITLE
Update links in intro-block.md and services-information.md

### DIFF
--- a/common-design-patterns/intro-block.md
+++ b/common-design-patterns/intro-block.md
@@ -146,7 +146,7 @@ title: Introduction block
     <h3>GCweb (WET) theme implementation reference</h3>
     <p>The implementation reference includes how to configure elements of the design system.</p>
     <ul>
-        <li><a href="https://wet-boew.github.io/GCWeb/design-patterns/gc-intro/gc-intro-image-en.html">Introduction block - GCWeb</a></li>
+        <li><a href="https://wet-boew.github.io/GCWeb/design-patterns/gc-intro/gc-intro-doc-en.html">Introduction block - GCWeb</a></li>
         <li><a href="https://wet-boew.github.io/GCWeb/docs/implementing-en.html">Quick implementation guide - GCWeb theme</a></li>
     </ul>    <h3>Implementations</h3>
     <p>Determine what best suits the type of page you're creating.</p>

--- a/common-design-patterns/services-information.md
+++ b/common-design-patterns/services-information.md
@@ -134,7 +134,7 @@ title: Services and information
   <h3>GCweb (WET) theme implementation reference</h3>
   <p>The implementation reference includes how to configure each element of the services and information pattern.</p>
 <ul>
-  <li><a href="https://wet-boew.github.io/GCWeb/components/gc-servinfo/gc-srvinfo.html">Services and information - GCWeb</a></li>
+  <li><a href="https://wet-boew.github.io/GCWeb/components/gc-srvinfo/gc-srvinfo-doc-en.html">Services and information - GCWeb</a></li>
 </ul>
   <h3>Implementations</h3>
     <p>Determine what best suits the type of page you're creating.</p>


### PR DESCRIPTION
This pull request updates the links in the intro-block.md and services-information.md files. The links were pointing to outdated URLs and have been corrected to the new URLs. This ensures that users are directed to the correct resources when accessing the introduction block and services and information sections.

## Alternate language PR
FR:  https://github.com/canada-ca/systeme-conception/pull/344