### PR TITLE
move files from global-footer, global-header subdirectories

### DIFF
--- a/common-design-patterns/breadcrumb-trail.md
+++ b/common-design-patterns/breadcrumb-trail.md
@@ -1,0 +1,214 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/fil-ariane.html"
+date: 2017-10-05
+dateModified: 2023-06-26
+description: "Guidance about using breadcrumbs on Canada.ca. The breadcrumb trail provides a series of navigational links that gives people a sense of where they are in relation to the site structure."
+title: "Breadcrumb trail"
+---
+<div class="row">
+  <div class="col-md-12 pull-left">
+    <ul class="list-inline small mrgn-bttm-sm" id="list-inline-desktop-only">
+      <li class="mrgn-rght-lg"> Last updated: {{ page.dateModified }}</li>
+    </ul>
+  </div>
+</div>
+<p><span class="label label-danger">Mandatory on standard and campaign pages</span></p>
+<p>The breadcrumb trail is a horizontal series of links that gives people a sense of where they are in relation to Canada.ca's navigation model.  It represents the location of a page in relation to its parent and provides a clear way to navigate to higher levels in the site structure.</p>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure class="mrgn-bttm-sm"><img src="../../images/01-breadcrumbs-main-en.png" class="img-responsive" alt=""></figure>
+</div>
+<section>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#when">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#content">Content and design</a></li>
+    <li><a href="#implementation">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#changes">Latest changes</a></li>
+  </ul>
+</section>
+<h2 id="when">When to use</h2>
+<p>The breadcrumb trail is mandatory on all pages, except transactional pages.</p>
+<h2 id="avoid">What to avoid</h2>
+<p>Don't program the breadcrumb trail to be generated dynamically based on a visitor's journey to a page. It should represent the location of a page as it stands in relation to the site's navigation model.</p>
+<p>Avoid long link labels that push content down on mobile. Use shortened versions of multi-word page titles when possible.</p>
+<p>Don't display the current page at the end of the breadcrumb trail (linked or unlinked). It increases the length of the breadcrumb unnecessarily, especially on mobile. The heading of the page is enough to let people know where they are.</p>
+<h2 id="content">Content and design</h2>
+<p>Find content and design specifications and visual examples.</p>
+<h3>Content specifications</h3>
+<p>Align the breadcrumb trail to the left directly below the menu button (or the divider line if there is no menu button).</p>
+<p>Use "Canada.ca" as the text of the first breadcrumb link on standard and campaign pages.</p>
+<ul>
+  <li>Link to the Canada.ca home page in the language of the current page.</li>
+</ul>
+<p>You can use either "Home" or the name of the process or application as the text of the first breadcrumb link on transactional pages that use a breadcrumb trail.</p>
+<ul>
+  <li>Link to the starting page of the process or the landing page of the application.</li>
+</ul>
+<p>Use a single right chevron icon to separate each breadcrumb link.</p>
+<p>Reflect the title of the page in the breadcrumb label.</p>
+<ul>
+  <li>Shorten breadcrumb labels where possible to improve readability and reduce space.</li>
+</ul>
+<p>For example, these breadcrumbs:</p>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> Immigration and citizenship <span class="glyphicon glyphicon-chevron-right small"></span> Canadian citizenship <span class="glyphicon glyphicon-chevron-right small"></span> Apply for Canadian citizenship <span class="glyphicon glyphicon-chevron-right small"></span> Prepare for the Canadian citizenship test and interview</p>
+</div>
+<p>Can be shortened to this:</p>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> Immigration and citizenship <span class="glyphicon glyphicon-chevron-right small"></span> Canadian citizenship <span class="glyphicon glyphicon-chevron-right small"></span> Apply <span class="glyphicon glyphicon-chevron-right small"></span> Prepare for the test and interview</p>
+</div>
+<h4>Accessibility</h4>
+<p>Include "You are here:" as invisible help text.</p>
+<h4>Interactions</h4>
+<p>When selected, each breadcrumb should bring the user to a unique page.</p>
+<h3>Design specifications</h3>
+<ul>
+  <li>Type: link</li>
+  <li>Position: top left</li>
+  <li>Font: Noto sans</li>
+  <li>Size: 16px</li>
+  <li>Text colour:
+    <ul>
+      <li>default link: #284162</li>
+      <li>selected link (on hover or focus): #0535d2</li>
+      <li>visited link: #7834bc</li>
+    </ul>
+  </li>
+  <li>Spacing
+    <ul>
+      <li>vertical padding: 13px</li>
+      <li>horizontal padding: 2px</li>
+      <li>margin top: 15px</li>
+      <li>line-height: 23px</li>
+    </ul>
+  </li>
+  <li>Icon: glyphicon-chevron-right</li>
+</ul>
+<h4>Accessibility</h4>
+<p>Code breadcrumbs as an ordered list.</p>
+<h4>Breadcrumb structure</h4>
+<p>Here are some examples of breadcrumbs for different locations on Canada.ca:</p>
+<h5 class="mrgn-tp-lg">Theme pages, institutional and organizational pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca</p>
+</div>
+<h5>First-level topic pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> [Parent theme]</p>
+</div>
+<h5>Second-level topic pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> [Parent theme] <span class="glyphicon glyphicon-chevron-right small"></span> [Parent topic]</p>
+</div>
+<h5>Corporate, program or policy content pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> [Institutional profile page]</p>
+</div>
+<h5>Partnering and collaborative arrangement profile pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca</p>
+</div>
+<h5>Basic search pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca</p>
+</div>
+<h5>Advanced search pages</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> [Basic search]</p>
+</div>
+<h5>Campaigns and promotions</h5>
+<p>Promotion campaigns don't need a breadcrumb trail. If you add one, it can lead back to the topic tree, the Institutional/Organizational profile, or to the Home page of Canada.ca.</p>
+<h5 class="mrgn-tp-lg">News</h5>
+<div class="container">
+  <p class="breadcrumb">Canada.ca <span class="glyphicon glyphicon-chevron-right small"></span> [Institutional profile page]</p>
+</div>
+<h5 class="mrgn-tp-lg">Application</h5>
+<div class="container">
+  <p class="breadcrumb">Home</p>
+</div>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Global header with breadcrumb trail  - large screen</b></figcaption>
+    <img src="../../images/01-breadcrumbs-main-en.png" class="img-responsive" alt=" ">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: global header with breadcrumb trail  - large screen</summary>
+      <p class="mrgn-tp-lg">The breadcrumbs appear under the menu button in a horizontal line.</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Global header – small screen</b></figcaption>
+    <img src="../../images/01-breadcrumbs-sm-en.png" class="img-responsive" alt=" ">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: global header with breadcrumb trail  - small screen</summary>
+      <p class="mrgn-tp-lg">The breadcrumbs appear under the menu button.</p>
+    </details>
+  </figure>
+</div>
+<h2 id="implementation">How to implement</h2>
+<p>Find working examples for implementing the breadcrumbs.</p>
+<h3>GCweb (WET) theme implementation reference</h3>
+<p>The implementation reference includes how to configure each element of the header.</p>
+<ul>
+  <li><a href="https://wet-boew.github.io/GCWeb/sites/breadcrumbs/breadcrumbs-en.html">Breadcrumbs - GCWeb (WET) documentation</a></li>
+  <li><a href="https://wet-boew.github.io/GCWeb/sites/header/header-docs-en.html">GCWeb (WET) header documentation</a></li>
+</ul>
+<h3>Implementations</h3>
+<p>Determine what best suits the type of page you're creating. Refer to your implementation's guidance if you want to exclude breadcrumbs.</p>
+<div class="row">
+  <div class="col-md-8">
+    <div class="wb-tabs mrgn-tp-lg">
+      <div class="tabpanels">
+        <details id="004" open="open">
+          <summary><strong>GC-AEM</strong></summary>
+          <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+          <ul>
+            <li><a href="https://www.gcpedia.gc.ca/gcwiki/images/9/9a/AEM-6.5-Documentation-Unit-3-7-Changing-the-Default-Breadcrumb.pdf">Changing the default breadcrumb (PDF - GCPedia link - only available on the Government of Canada network)</a></li>
+            <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (GCPedia link - only available on the Government of Canada network)</a></li>
+          </ul>
+        </details>
+        <details id="005">
+          <summary><strong>CDTS</strong></summary>
+          <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+          <ul>
+            <li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_47/cdts/samples/breadcrumbs-en.html">Breadcrumbs - CDTS documentation </a></li>
+            <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+          </ul>
+        </details>
+        <details id="006">
+          <summary><strong>Drupal WxT</strong></summary>
+          <p class="mrgn-tp-lg">For Drupal WxT:</p>
+          <ul>
+            <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+          </ul>
+        </details>
+      </div>
+    </div>
+  </div>
+</div>
+<h2 id="research">Research and rationale</h2>
+<p>Consult research findings and policy rationale.</p>
+<h3>Research findings</h3>
+<ul>
+  <li><a href="https://blog.canada.ca/2020/08/10/CanadaDotCa-trusted-source.html">Canada.ca is a trusted source</a><br>
+    Explains the decision to use "Canada.ca" as the label for the first link in the breadcrumb</li>
+  <li><a href="{{ site.url }}/research-summaries/wayfinding-on-canada-ca.html">Wayfinding on Canada.ca research summary</a><br>
+    Research showing that people navigating on the site use breadcrumb links nearly twice as often as they use the Theme and topic menu</li>
+</ul>
+<h3>Policy rationale</h3>
+<p>The spacing specifications for the breadcrumb links are designed so that touch targets meet WCAG AAA requirements.</p>
+<p>As part of the global header, the breadcrumb is a mandatory element under the <cite>Canada.ca Specifications.</cite></p>
+<ul>
+  <li><a href="https://design.canada.ca/specifications/mandatory-elements.html">Mandatory elements of the design system</a></li>
+</ul>
+<h2 id="changes">Latest changes</h2>
+<dl class="dl-horizontal">
+  <dt>
+    <time datetime="2023-06-26" class="link-muted">2023-06-26</time>
+  </dt>
+  <dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, research findings and policy rationale</dd>
+</dl>

--- a/common-design-patterns/contextual-signin.md
+++ b/common-design-patterns/contextual-signin.md
@@ -1,0 +1,196 @@
+---
+altLangPage: https://conception.canada.ca/configurations-conception-communes/connexion-contextuel.html
+date: 2022-09-23
+dateModified: 2023-06-26
+description: The Sign in button directs to authenticated government accounts. It's a persistent call to action in a group of related pages.
+title: Contextual Sign in button
+---
+<div class="row">
+	<div class="col-md-12 pull-left">
+		<ul class="list-inline small mrgn-bttm-sm" style="line-height:1.65em" id="list-inline-desktop-only">
+			<li class="mrgn-rght-lg">Last updated: {{ page.dateModified }}</li>
+		</ul>
+	</div>
+</div>
+<p>The Sign in button is an optional header element that directs people to government accounts that require authentication. It is a contextual and persistent call to action within a group of related pages.</p>
+<div class="pattern-demo">
+  <figure class="mrgn-bttm-lg">
+    <figcaption><b>Sign in - large screen</b></figcaption>
+    <img src="../../images/01-sign-in-desktop-en.png" class="img-responsive brdr" alt="Sign in header for large screens">
+  </figure>
+  <figure class="mrgn-bttm-lg">
+    <figcaption><b>Sign in - small screen</b></figcaption>
+    <img src="../../images/01-sign-in-mobile-en.png" class="img-responsive brdr" alt="Sign in header for small screens">
+  </figure>
+</div>
+<section>
+	<h2>On this page</h2>
+	<ul>
+		<li><a href="#when">When to use</a></li>
+		<li><a href="#avoid">What to avoid</a></li>
+		<li><a href="#content">Content and design</a></li>
+		<li><a href="#how">How to implement</a></li>
+		<li><a href="#research">Research and rationale</a></li>
+		<li><a href="#latest">Latest changes</a></li>
+	</ul>
+</section>
+<section>
+	<h2 id="when">When to use</h2>
+	<p>Add the Sign in button when signing in to an account is a key task within a series of pages. This includes:</p>
+	<ul>
+		<li>pages where there is already a link or button to an account or accounts</li>
+		<li>a set of pages that support a specific service (such as Employment insurance, GST)</li>
+		<li>pages where analytics show people are using the menu or the search bar to access an account</li>
+	</ul>
+	<p>You can use the Sign in button in addition to a supertask button on the same page. If you have an existing super task button, don't remove it. Instead, add the Sign in button. You may see changes in use over time in your analytics that show that you can remove the super task button.</p>
+</section>
+<section>
+	<h2 id="avoid">What to avoid</h2>
+	<ul>
+		<li>Use Sign in, not Log in</li>
+		<li>Exclude the Sign in button from:
+			<ul>
+				<li>account-chooser pages or sign-in process pages</li>
+				<li>pages that aren't related to the authenticated service</li>
+			</ul>
+		</li>
+	</ul>
+</section>
+<section>
+	<h2 id="content">Content and design</h2>
+	<p>Find content and design specifications and visual examples.</p>
+	<h3>Content specifications</h3>
+	<p>Use “Sign in” as the label</p>
+  <ul>
+    <li><b>Small screens</b>: total of 12 characters including spaces (no additional descriptive text)</li>
+    <li><b>Large/medium screens</b>: total of 25 characters including spaces (for additional descriptive text if needed, such as “Sign in to [account name]”)</li>
+  </ul>
+</section>
+<section>
+	<h3>Interactions</h3>
+	<p>Link the Sign in button directly to the page where you begin your sign-in process, or to an account-chooser page with the different accounts you can sign in to.</p>
+	<h3>Design specifications</h3>
+	<p>Button structure</p>
+	<ul>
+		<li>Border:
+			<ul>
+				<li>weight: 1px</li>
+				<li>style: solid</li>
+				<li>radius: 0</li>
+			</ul>
+		</li>
+		<li>Font:
+			<ul>
+				<li>weight: 400</li>
+				<li>family: Lato</li>
+				<li>size: 16px</li>
+				<li>colour: #fff</li>
+			</ul>
+		</li>
+		<li>Margin:
+			<ul>
+				<li>top margin: 5px</li>
+				<li>other margins: 0px</li>
+			</ul>
+		</li>
+		<li>Padding:
+			<ul>
+				<li>top: 10px</li>
+				<li>bottom: 10px</li>
+				<li>left: 14px</li>
+				<li>right: 14px</li>
+			</ul>
+		</li>
+	</ul>
+	<p>Default state</p>
+	<ul>
+		<li>background colour: #26374a</li>
+		<li>border colour: #26374a</li>
+	</ul>
+	<p>Hover state</p>
+	<ul>
+		<li>background colour: #444</li>
+		<li>border colour: #444</li>
+	</ul>
+	<h3> Visual examples</h3>
+	<div class="pattern-demo mrgn-tp-lg">
+		<figure>
+			<figcaption><b>Contextual Sign in button - large screen</b></figcaption>
+			<img src="../../images/01-sign-in-desktop-en.png" class="img-responsive brdr" alt="Sign in header for large screens">
+			<details class="mrgn-tp-md">
+				<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: Contextual Sign in button - large screen</summary>
+				<p class="mrgn-tp-lg">Standard header of an English Canada.ca page with the Sign in button highlighted</p>
+			</details>
+		</figure>
+	</div>
+	<div class="pattern-demo mrgn-tp-lg">
+		<figure>
+			<figcaption><b>Contextual Sign in button - small screen</b></figcaption>
+			<img src="../../images/01-sign-in-mobile-en.png" class="img-responsive brdr" alt="Sign in header for small screens">
+			<details class="mrgn-tp-md">
+				<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: Contextual Sign in button - small screen</summary>
+				<p class="mrgn-tp-lg">Standard header of an English Canada.ca page with the Sign in button highlighted</p>
+			</details>
+		</figure>
+	</div>
+</section>
+<section>
+	<h2 id="how">How to implement</h2>
+	<p>Find working examples and code for implementing the Sign in button.</p>
+	<h3>GCweb (WET) theme implementation reference</h3>
+	<p>The implementation reference includes how to configure each element of the header.</p>
+	<ul>
+		<li><a href="https://wet-boew.github.io/GCWeb/sites/authentication/authentication-en.html">Authentication patterns</a></li>
+	</ul>
+	<h3>Implementations</h3>
+	<p>Determine what best suits the type of page you're creating.</p>
+	<div class="row">
+		<div class="col-md-8">
+			<div class="wb-tabs mrgn-tp-lg">
+				<div class="tabpanels">
+				<details id="004" open="open">
+					<summary><strong>GC-AEM</strong></summary>
+					<p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+					<ul>
+						<li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (GCPedia link - only available on the Government of Canada network)</a></li>
+					</ul>
+				</details>
+				<details id="005">
+					<summary><strong>CDTS</strong></summary>
+					<p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+					<ul>
+						<li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+					</ul>
+				</details>
+				<details id="006">
+					<summary><strong>Drupal WxT</strong></summary>
+					<p class="mrgn-tp-lg">For Drupal WxT:</p>
+					<ul>
+						<li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+					</ul>
+				</details>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+<section>
+	<h2 id="research">Research and rationale</h2>
+	<ul>
+		<li><a href="https://blog.canada.ca/2022/09/23/introducing-contextual-sign-in-button">Introducing the contextual Sign in button</a></li>
+	</ul>
+	<p>We introduced the contextual sign in button to improve findability for this top task.</p>
+</section>
+<section>
+	<h2 id="latest">Latest changes</h2>
+	<dl class="dl-horizontal">
+		<dt>
+			<time>2023-06-26</time>
+		</dt>
+		<dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, and policy rationale</dd>
+		<dt>
+			<time>2022-08-17</time>
+		</dt>
+		<dd>Expanded Sign in button guidance</dd>
+	</dl>
+</section>

--- a/common-design-patterns/language-toggle.md
+++ b/common-design-patterns/language-toggle.md
@@ -1,0 +1,187 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/changer-langue.html"
+date: 2017-10-05
+dateModified: 2023-06-26
+description: "Guidance about using the language toggle on Canada.ca. Government of Canada content is available in both official languages. A language toggle in the global header provides access to the corresponding page in the other official language."
+title: "Language toggle"
+---
+<div class="row">
+  <div class="col-md-12 pull-left">
+    <ul class="list-inline small mrgn-bttm-sm" id="list-inline-desktop-only">
+      <li class="mrgn-rght-lg"> Last updated: {{ page.dateModified }}</li>
+    </ul>
+  </div>
+</div>
+<p><span class="label label-danger">Mandatory</span></p>
+<p>All public-facing Government of Canada content is available in both official languages. A language toggle in the global header provides access to the corresponding page in the other official language.</p>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure class="mrgn-bttm-sm"><img src="../../images/01-lang-toggle-en.png" class="img-responsive" alt=""></figure>
+</div>
+<section>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#when">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#content">Content and design</a></li>
+    <li><a href="#implementation">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#changes">Latest changes</a></li>
+  </ul>
+</section>
+
+<h2 id="when">When to use</h2>
+<p>The language toggle is mandatory on all pages.</p>
+<p>New transactional pages for web applications must allow people to toggle between official languages. Legacy web applications that don’t support toggling should be updated or replaced. Until then, you can omit the language toggle if its use results in a loss of data.</p>
+
+<h2 id="avoid">What to avoid</h2>
+<p>Don’t put other language options in the language toggle. It is only for English and French. Links to content in other languages should appear in the content area of the page.</p>
+<p>Don’t use the language toggle to point to anything other than the corresponding page in the equivalent language.</p>
+
+<h2 id="content">Content and design</h2>
+<p>Find content and design specifications and visual examples.</p>
+
+<h3>Content specifications</h3>
+<p>Ensure that the language toggle links to the corresponding page in the alternate language.</p>
+
+<h4>Large screens</h4>
+<ul>
+  <li>On English pages, the link label text is “Français”</li>
+  <li>On French pages, the link label text is “English”</li>
+</ul>
+<h4>Small screens</h4>
+<p>For small screens, the language toggle uses a 2-letter abbreviation for each language:</p>
+<ul>
+  <li>On English pages, the link label text is “FR” in uppercase</li>
+  <li>On French pages, the link label text is “EN” in uppercase</li>
+</ul>
+<h4>Accessibility</h4>
+<ul>
+  <li>Add the full name of the language in the title attribute for the abbreviated language toggle
+    <ul>
+      <li>the abbreviation title for EN is “English”</li>
+      <li>the abbreviation title for FR is “Français”</li>
+    </ul>
+  </li>
+</ul>
+<h4>Interactions</h4>
+<ul>
+  <li>When selected, the language toggle brings the user to the alternate language version of the page they were on</li>
+</ul>
+<h3>Design specifications</h3>
+<ul>
+  <li>Type: link</li>
+  <li>Position: top-right corner</li>
+  <li>Font: Lato</li>
+  <li>Size: 1.2 em</li>
+  <li>Text colour:
+    <ul>
+      <li>default link: #284162</li>
+      <li>selected link (on hover or focus): #0535d2</li>
+      <li>visited link: #284162</li>
+    </ul>
+  </li>
+</ul>
+<h4>Accessibility</h4>
+<ul>
+  <li>Label the language toggle code so that it’s spoken in the correct language if read aloud by assistive technologies</li>
+  <li>Ensure that the text label for the language toggle won’t be translated by browser translation tools</li>
+</ul>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Language toggle (English page) - large screen</b></figcaption>
+    <img src="../../images/01-lang-toggle-en.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: language toggle (English page) - large screen</summary>
+      <p class="mrgn-tp-lg">Standard header of an English Canada.ca page with a highlight of the linked word Français in the top-right corner</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Language toggle (French page) - large screen</b></figcaption>
+    <img src="../../images/01-lang-toggle-fr.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: language toggle (French page) - large screen</summary>
+      <p class="mrgn-tp-lg">Standard header of a French Canada.ca page with a highlight of the linked word English in the top-right corner</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Language toggle (English page) - small screen</b></figcaption>
+    <img src="../../images/01-lang-toggle-sm-en.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: language toggle - small screen</summary>
+      <p class="mrgn-tp-lg">Standard header of an English Canada.ca page with a highlight of the linked abbreviation FR in the top-right corner</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Language toggle (French page) - small screen</b></figcaption>
+    <img src="../../images/01-lang-toggle-sm-fr.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: Language toggle (French page) - small screen</summary>
+      <p class="mrgn-tp-lg">Standard header of a French Canada.ca page with a highlight of the linked abbreviation EN in the top-right corner</p>
+    </details>
+  </figure>
+</div>
+<h2 id="implementation">How to implement</h2>
+<p>Find working examples for implementing the language toggle.</p>
+<h3>GCweb (WET) theme implementation reference</h3>
+<p>The implementation reference includes how to configure each element of the header.</p>
+<ul>
+  <li><a href="https://wet-boew.github.io/GCWeb/sites/header/header-docs-en.html">GCWeb (WET) header documentation</a></li>
+</ul>
+<h3>Implementations</h3>
+<p>Determine what best suits the type of page you're creating.</p>
+<div class="row">
+  <div class="col-md-8">
+    <div class="wb-tabs mrgn-tp-lg">
+      <div class="tabpanels">
+        <details id="004" open="open">
+          <summary><strong>GC-AEM</strong></summary>
+          <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+          <ul>
+            <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (GCPedia link - only available on the Government of Canada network)</a></li>
+          </ul>
+        </details>
+        <details id="005">
+          <summary><strong>CDTS</strong></summary>
+          <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+          <ul>
+            <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+          </ul>
+        </details>
+        <details id="006">
+          <summary><strong>Drupal WxT</strong></summary>
+          <p class="mrgn-tp-lg">For Drupal WxT:</p>
+          <ul>
+            <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+          </ul>
+        </details>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="cnt-wdth-lmtd">
+  <h2 id="research">Research and rationale</h2>
+  <p>Consult policy rationale.</p>
+  <h3>Policy rationale</h3>
+  <p>As part of the global header, the language toggle is a mandatory element under the <cite>Canada.ca Specifications.</cite></p>
+  <ul>
+    <li><a href="https://design.canada.ca/specifications/mandatory-elements.html">Mandatory elements of the design system</a></li>
+  </ul>
+  <p>All Government of Canada communications must be available in both official languages.</p>
+  <ul>
+    <li><a href="https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=26160">Policy on Official Languages</a></li>
+  </ul>
+  <h2 id="changes">Latest changes</h2>
+  <dl class="dl-horizontal">
+    <dt>
+      <time>2023-06-26</time>
+    </dt>
+    <dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, and policy rationale</dd>
+  </dl>
+</div>

--- a/common-design-patterns/search-box.md
+++ b/common-design-patterns/search-box.md
@@ -1,0 +1,150 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/champ-recherche.html"
+date: 2017-10-05
+dateModified: 2023-06-26
+description: "Guidance about using the site search box on Canada.ca. The site search box allows people to search Government of Canada content. It appears in the global header across Canada.ca."
+title: "Site search box"
+---
+<div class="row">
+  <div class="col-md-12 pull-left">
+    <ul class="list-inline small mrgn-bttm-sm" id="list-inline-desktop-only">
+      <li class="mrgn-rght-lg"> Last updated: {{ page.dateModified }}</li>
+    </ul>
+  </div>
+</div>
+<p><span class="label label-danger">Mandatory on standard and campaign pages</span></p>
+<p>The site search box is an element of the global header. It allows people to search Government of Canada content using a simple search field.</p>
+<p>Results for site search are at the level of all Government of Canada web content, or a subset of content at the department or agency level.</p>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure class="mrgn-bttm-sm"><img src="../../images/01-site-search-en.png" class="img-responsive" alt=""></figure>
+</div>
+<section>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#when">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#content">Content and design</a></li>
+    <li><a href="#implementation">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#changes">Latest changes</a></li>
+  </ul>
+</section>
+<h2 id="when">When to use</h2>
+<p>The site search box is mandatory on all pages, except transactional pages.</p>
+<h2 id="avoid">What to avoid</h2>
+<p>Don’t use the site search box for searching anything other than content indexed by GC Search. Place search for other datasets within the content area of the page.</p>
+<h2 id="content">Content and design</h2>
+<p>Find content and design specifications and visual examples.</p>
+<h3>Content specifications</h3>
+<p>The site search box consists of 3 visual elements:</p>
+<ul>
+  <li>text input field (maximum 170 characters)</li>
+  <li>input box placeholder text</li>
+  <li>search button with magnifying glass icon</li>
+</ul>
+<p>In the text input field, the placeholder label is:</p>
+<ul>
+  <li>"Search Canada.ca" in English</li>
+  <li>"Rechercher dans Canada.ca" in French</li>
+</ul>
+<p>The placeholder label in a contextualized search box is:</p>
+<ul>
+  <li>"Search [institution]" in English</li>
+  <li>"Rechercher dans [institution]" in French</li>
+</ul>
+<h4>Interactions</h4>
+<ul>
+  <li>Searches query the GC Search index. Typing a search term in the input field and selecting the search icon opens a results page.</li>
+</ul>
+<h3>Design specifications</h3>
+<ul>
+  <li>Position: top-right corner of the global header area, below the language toggle link</li>
+  <li>Form class: form-inline</li>
+  <li>Button icon: glyphicon-search glyphicon</li>
+  <li>Button class: btn btn-primary btn-small</li>
+  <li>Colour: #26374a</li>
+  <li>Length of input field: maxlength=170</li>
+  <li>Value size: 34</li>
+</ul>
+<p>The search elements are responsive.  They scale according to screen size.</p>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Site search box - large screen</b></figcaption>
+    <img src="../../images/01-site-search-en.png" class="img-responsive" alt=" ">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: site search box - large screen</summary>
+      <p class="mrgn-tp-lg">The search box appears in the top-right corner, underneath the language toggle and directly across from the Government of Canada signature. </p>
+      <p>The site search bar is a rectangle, defined by a light grey border. Within the rectangle are the words, ‘Search Canada.ca’.  To the right of the rectangle is a blue square with a white magnifying glass icon within.</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Site search box - small screen</b></figcaption>
+    <img src="../../images/01-site-search-sm-en.png" class="img-responsive" alt=" ">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: site search box - small screen</summary>
+      <p class="mrgn-tp-lg">The search box appears in the header, directly below the Government of Canada signature and the language toggle. It spans across the screen.</p>
+      <p>The site search bar is a rectangle, defined by a light grey border. Within the rectangle are the words, ‘Search Canada.ca’.  To the right of the rectangle is a blue square with a white magnifying glass icon within. </p>
+    </details>
+  </figure>
+</div>
+<h2 id="implementation">How to implement</h2>
+<p>Find working examples for implementing the site search box.</p>
+<h3>GCweb (WET) theme implementation reference</h3>
+<p>The implementation reference includes how to configure each element of the header.</p>
+<ul>
+  <li><a href="https://wet-boew.github.io/GCWeb/sites/header/header-docs-en.html">GCWeb (WET) header documentation</a></li>
+</ul>
+<h3>Implementations</h3>
+<p>Determine what best suits the type of page you're creating.</p>
+<div class="row">
+  <div class="col-md-8">
+    <div class="wb-tabs mrgn-tp-lg">
+      <div class="tabpanels">
+        <details id="004" open="open">
+          <summary><strong>GC-AEM</strong></summary>
+          <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+          <ul>
+            <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (GCPedia link - only available on the Government of Canada network)</a></li>
+          </ul>
+        </details>
+        <details id="005">
+          <summary><strong>CDTS</strong></summary>
+          <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+          <ul>
+            <li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_45/cdts/samples/custom-search-en.html">Custom search</a> - configuration options for the site search box</li>
+            <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+          </ul>
+        </details>
+        <details id="006">
+          <summary><strong>Drupal WxT</strong></summary>
+          <p class="mrgn-tp-lg">For Drupal WxT:</p>
+          <ul>
+            <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+          </ul>
+        </details>
+      </div>
+    </div>
+  </div>
+</div>
+<h3>Configure search</h3>
+<p>The Principal Publisher provides support for GC Search adoption, search configuration, indexing of web pages, functionality errors and other search related requests:</p>
+<ul>
+  <li><a href="https://www.gcpedia.gc.ca/wiki/GC_Search_Support">GC Search Support (only available on the GC network)</a></li>
+</ul>
+<h2 id="research">Research and rationale</h2>
+<p>Placing site search in the top-right corner of a web page is an established web convention.</p>
+<h3>Policy rationale</h3>
+<p>As part of the global header, the site search box is a mandatory element under the <cite>Canada.ca Specifications.</cite></p>
+<ul>
+  <li><a href="https://design.canada.ca/specifications/mandatory-elements.html">Mandatory elements of the design system</a></li>
+</ul>
+<h2 id="changes">Latest changes</h2>
+<dl class="dl-horizontal">
+  <dt>
+    <time datetime="2023-06-26" class="link-muted">2023-06-26</time>
+  </dt>
+  <dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, support for search configuration, and policy rationale</dd>
+</dl>

--- a/common-design-patterns/signature.md
+++ b/common-design-patterns/signature.md
@@ -1,0 +1,135 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/signature.html"
+date: 2017-10-05
+dateModified: 2023-06-26
+description: "Guidance about using the Government of Canada signature on Canada.ca. The signature is an official symbol of the Government of Canada. It always appears in the global header across Canada.ca."
+title: "Government of Canada signature"
+---
+<div class="row">
+  <div class="col-md-12 pull-left">
+    <ul class="list-inline small mrgn-bttm-sm" id="list-inline-desktop-only">
+      <li class="mrgn-rght-lg"> Last updated: {{ page.dateModified }}</li>
+    </ul>
+  </div>
+</div>
+<p><span class="label label-danger">Mandatory on all pages</span></p>
+<p>The Government of Canada signature is a mandatory element of the global header. The signature is an official symbol of the Government of Canada. It combines the flag symbol and “Government of Canada” in both official languages.</p>
+<p>The Government of Canada signature helps users identify that the page they are on belongs to the Government of Canada.</p>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure class="mrgn-bttm-sm"><img src="../../images/01-sig-en.png" class="img-responsive" alt=""></figure>
+</div>
+<section>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#when">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#content">Content and design</a></li>
+    <li><a href="#implementation">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#changes">Latest changes</a></li>
+  </ul>
+</section>
+<h2 id="when">When to use</h2>
+<p>The Government of Canada signature is mandatory on all pages.</p>
+<h2 id="avoid">What to avoid</h2>
+<p>Don’t modify the signature.</p>
+<p>Don’t change the colour of the flag. It must appear in colour (red), not in black and white.</p>
+<p>Don’t modify the text (Government of Canada Gouvernement du Canada) or the font.</p>
+<h2 id="content">Content and design</h2>
+<p>Find content and design specifications and visual examples.</p>
+<h3>Content specifications</h3>
+  <p>The Government of Canada signature appears in the top-left corner of the page.</p>
+  <p>The signature is composed of the flag symbol in Federal Identity Program red, followed by the words Government of Canada in English and Gouvernement du Canada in French, both in black text.</p>
+  <p>The signature must appear as English first on English pages and French first on French pages.</p>
+<h4>Accessibility</h4>
+<p>Include Government of Canada as alt text on the English side, Gouvernement du Canada as alt text on the French side.</p>
+<h4>Interactions</h4>
+<p>When selected, the signature brings the user to the homepage of Canada.ca.</p>
+<h3>Design specifications</h3>
+<ul>
+  <li>Type: image</li>
+  <li>Position: top left</li>
+  <li>Flag symbol colour: FIP red (#eb2d37)</li>
+  <li>Text colour: black (#000000)</li>
+  <li>Alt text: Government of Canada</li>
+</ul>
+<p>The signature is a Scalable Vector Graphics (SVG) file, configured to scale automatically according to screen size.</p>
+<p>The signature is an image file that must be formatted according to the <a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard.html">Design Standard for the Federal Identity Program</a>.</p>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Government of Canada signature - large screen</b></figcaption>
+    <img src="../../images/01-sig-en.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: Government of Canada signature - large screen</summary>
+      <p class="mrgn-tp-lg">The Government of Canada signature is in the top-left corner of the website. It is composed of the flag symbol in red, followed by the words <strong>Government of Canada</strong> in English and <strong>Gouvernement du Canada</strong> in French, both in black text.</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+  <figure>
+    <figcaption><b>Government of Canada signature - small screen</b></figcaption>
+    <img src="../../images/01-sig-sm-en.png" class="img-responsive" alt="">
+    <details class="mrgn-tp-md">
+      <summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: Government of Canada signature - small screen</summary>
+      <p class="mrgn-tp-lg">The Government of Canada signature is in the top-left corner of the website. It is composed of the flag symbol in red, followed by the words <strong>Government of Canada</strong> in English and <strong>Gouvernement du Canada</strong> in French, both in black text.</p>
+    </details>
+  </figure>
+</div>
+<h2 id="implementation">How to implement</h2>
+<p>Find working examples for implementing the GC signature, an element of the global header.</p>
+<h3>GCweb (WET) theme implementation reference</h3>
+<p>The implementation reference includes how to configure each element of the header.</p>
+<ul>
+  <li><a href="https://wet-boew.github.io/GCWeb/sites/header/header-docs-en.html">GCWeb (WET) header documentation</a></li>
+</ul>
+<h3>Implementations</h3>
+<p>Determine what best suits the type of page you're creating.</p>
+<div class="row">
+  <div class="col-md-8">
+    <div class="wb-tabs mrgn-tp-lg">
+      <div class="tabpanels">
+        <details id="004" open="open">
+          <summary><strong>GC-AEM</strong></summary>
+          <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+          <ul>
+            <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (GCPedia link - only available on the Government of Canada network)</a></li>
+          </ul>
+        </details>
+        <details id="005">
+          <summary><strong>CDTS</strong></summary>
+          <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+          <ul>
+            <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+          </ul>
+        </details>
+        <details id="006">
+          <summary><strong>Drupal WxT</strong></summary>
+          <p class="mrgn-tp-lg">For Drupal WxT:</p>
+          <ul>
+            <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+          </ul>
+        </details>
+      </div>
+    </div>
+  </div>
+</div>
+<h2 id="research">Research and rationale</h2>
+<p>Consult research findings and policy rationale.</p>
+<h3>Research findings</h3>
+<p>Trust and consistency are essential. Our Canada.ca Trust Study and prior research show that a consistent header is necessary to maintaining a trusted brand.</p>
+<p>For example, people trust the page more when the flag in the Government of Canada signature is red.</p>
+<p>If you want to know more about this research, contact the Digital Transformation Office at <a href="mailto:{{ site.emails.dto }}">{{ site.emails.dto }}</a>.</p>
+<h3>Policy rationale</h3>
+<p>The Government of Canada signature is defined by the Federal Identity Program. As a part of the global header, it is a mandatory element under the <cite>Canada.ca Specifications.</cite></p>
+<ul>
+  <li><a href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard/colour-design-standard-fip.html">Design Standard for the Federal Identity Program</a></li>
+  <li><a href="https://design.canada.ca/specifications/mandatory-elements.html">Mandatory elements of the design system</a></li>
+</ul>
+<h2 id="changes">Latest changes</h2>
+<dl class="dl-horizontal">
+  <dt>
+    <time>2023-06-26</time>
+  </dt>
+  <dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, research findings and policy rationale</dd>
+</dl>

--- a/common-design-patterns/site-footer-contextual.md
+++ b/common-design-patterns/site-footer-contextual.md
@@ -1,0 +1,196 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/pied-page-contextuelle.html"
+date: 2022-11-30
+dateModified: 2023-04-06
+description: "This is an optional element of the global (site-wide) footer."
+title: "Global footer: Contextual band"
+---
+<p><strong>Last updated</strong>: {{ page.dateModified }}</p>
+<section>
+  <p><span class="label label-info">Optional</span></p>
+  <p>The contextual footer band is an optional element of the global footer.</p>
+  <p>It provides support links that are specific to an entire group of pages, such as contact details for a program. A group of pages
+    might be an entire theme, all the pages related to a specific program or service, or all the pages related to a single
+    organization.</p>
+  <p><strong>2022 design update</strong>: We’ve recently updated this pattern as part of a new navigation strategy coming
+    out of the Wayfinding research project. To find out more about this project, visit the <a href="#research">Research and rationale</a> section on this page.</p>
+  <div class="pattern-demo mrgn-tp-lg"> <img src="../../images/footer-contextual.jpg" class="img-responsive"
+				alt="Diagram of contextual band for large screens. Text version below:"> </div>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#use">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#design">Content and design</a></li>
+    <li><a href="#implement">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#latest">Latest changes</a></li>
+    <li><a href="#discuss">Discussion</a></li>
+  </ul>
+  <h2 id="use">When to use</h2>
+  <p>The footer generally acts as a rescue for people. They check it if they don't find what they want in the main content of
+    the page.</p>
+  <p>Use a contextual footer band when you have a consistent set of rescue links that should be available throughout a
+    specific group of pages.</p>
+  <ul>
+    <li>For example, the Taxes theme pages could have a contextual footer band with a link to Contact the CRA.</li>
+  </ul>
+  <p><strong>Tip:</strong> If your pages have previously had a contextualized Contact us link in the global footer, you should add a contextual footer band.</p>
+  <h2 id="avoid">What to avoid</h2>
+  <p>The content of this band shouldn’t duplicate the Government of Canada links in the <a href="./site-footer.html">main footer band</a>.</p>
+  <p>Don’t use this band for a single page. It should apply to a group of related pages.</p>
+  <h2 id="design">Content and design</h2>
+  <p>Include only 1 contextual footer band on any page.</p>
+  <h3>Content specifications</h3>
+  <p>Limit this band to a single row with a maximum of 3 links.</p>
+  <p>Include a heading that’s relevant to the content in this band, such as the name of the organization, theme or program.</p>
+  <p>Remember that it's a rescue pattern when you're choosing content for this band. It’s ok if something like a contact link appears
+    in both the content area and the footer. If you have a page that has contact information in the body, it’s ok to have another contact link in the footer.</p>
+  <p>Choose links that people will expect to find in a footer based on web conventions. Common contextual footer links could
+    include:</p>
+  <ul>
+    <li>Contact [...] or [...] Contacts (link to the organization or program contact page)</li>
+    <li>Careers (link to job postings)</li>
+    <li>News (or other curated indexes such as consultations)</li>
+  </ul>
+  <h3>Design specifications</h3>
+  <p>Design specifications for this band are:</p>
+  <ul>
+    <li>Background colour: Contextual footer blue (#33465c)</li>
+    <li>Text colour: white (#FFFFFF)</li>
+    <li>Font family:
+      <ul>
+        <li>header: Lato</li>
+        <li>links: Noto Sans</li>
+      </ul>
+    </li>
+    <li>Text size (base size for the footer is 16px):
+      <ul>
+        <li>header: 19px or 1.2em</li>
+        <li>links: 14px or 0.875em</li>
+      </ul>
+    </li>
+    <li>Font weight:
+      <ul>
+        <li>header: 700 or bold</li>
+        <li>links: 400 or regular</li>
+      </ul>
+    </li>
+    <li>Columns: 3 column in large and medium screen formats, 1 column in small screen format</li>
+  </ul>
+  <h3>Visual examples</h3>
+  <p>The contextual band should remain the same for the whole group of pages under the theme or institution.</p>
+  <div class="pattern-demo">
+    <figure class="mrgn-bttm-lg">
+      <figcaption><b>Example for the Veterans and military theme</b></figcaption>
+      <img src="../../images/contextual-footer-theme-en.jpg" class="img-responsive" alt="Contextual band for a theme. Text version below:">
+      <details>
+        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+        <p>Contextual band for the Veterans and military theme with the title “Contacts” and 3 contextual links: “Veterans contacts,” “Military contacts,” and “Contact the RCMP”</p>
+      </details>
+    </figure>
+  </div>
+  <div class="pattern-demo">
+    <figure class="mrgn-bttm-lg">
+      <figcaption><b>Example for an institution</b></figcaption>
+      <img src="../../images/contextual-footer-institutional-en.jpg" class="img-responsive" alt="Contextual band for an institution. Text version below:">
+      <details>
+        <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+        <p>Contextual band for an institution with the title “Agriculture and Agri-Food Canada” and 3 contextual links: “Contact AAFC,” “News,” and “Consultations”</p>
+      </details>
+    </figure>
+  </div>
+</section>
+<section>
+  <h2 id="implement">How to implement</h2>
+  <h3>GCweb (WET) theme implementation reference</h3>
+  <h4>Default</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+  </ul>
+  <h4>Alternate options for standard pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/footers-en.html">Complete footer (contextual, main and sub-footer bands)</a></li>
+  </ul>
+  <h4>Alternate options for transactional or campaign pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-main-en.html">Main band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-main-en.html">Contextual band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-contextual-en.html">Contextual band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-corporate-en.html">Sub-footer band only</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footers-en.html">Sub-footer band only with no optional links</a></li>
+  </ul>
+</section>
+<section>
+  <h3>Implementations</h3>
+  <p>Determine the footer configuration that best suits your needs for the type of page you're creating. Refer to your implementation's guidance to customize the contextual band or sub-footer band links.</p>
+  <div class="wb-tabs mrgn-tp-lg">
+    <div class="tabpanels">
+      <details id="004" open="open">
+        <summary><strong>GC-AEM</strong></summary>
+        <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+        <ul>
+          <li><a href="https://www.gcpedia.gc.ca/gcwiki/images/2/22/AEM-6.5-Documentation-Unit_3-1-1-_Customizing_Global_Footer.pdf">Customizing the Global footer (PDF - only available on the Government of Canada network)</a></li>
+          <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (only available on the Government of Canada network)</a></li>
+        </ul>
+      </details>
+      <details id="005">
+        <summary><strong>CDTS</strong></summary>
+        <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+        <ul>
+          <li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_47/cdts/samples/footer-en.html">Complete footer (contextual, main, sub-footer bands)</a></li>
+          <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+        </ul>
+      </details>
+      <details id="006">
+        <summary><strong>Drupal WxT</strong></summary>
+        <p class="mrgn-tp-lg">For Drupal WxT:</p>
+        <ul>
+          <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+        </ul>
+        <p>2023 footer update:</p>
+        <ul>
+          <li><a href="https://github.com/drupalwxt/wxt/releases/tag/4.4.1">Drupal WxT (4.4.1) release notes</a></li>
+          <li><a href="https://drupalwxt.github.io/en/docs/general/update/">Drupal WxT update process</a></li>
+        </ul>
+      </details>
+    </div>
+  </div>
+</section>
+<section>
+  <h2 id="research">Research and rationale</h2>
+  <p>We updated the global footer for Canada.ca to align with a new overall navigation strategy that came out of the
+    Wayfinding research project.</p>
+  <ul>
+    <li><a href="{{ site.url }}/research-summaries/wayfinding-on-canada-ca">Wayfinding on Canada.ca research summary</a><br>
+      This summary explains the context of the research and the insights that drove the design updates.</li>
+    <li><a href="https://blog.canada.ca/2022/12/21/wayfinding-research-project">Wayfinding research project improves our approach to navigation on Canada.ca</a><br>
+      This blog post explains the changes that are being made to the Canada.ca design, and how they are being implemented.</li>
+  </ul>
+</section>
+<section>
+  <h2 id="latest">Latest changes</h2>
+  <dl class="dl-horizontal">
+    <dt>
+      <time datetime="2023-02-08" class="link-muted">2023-02-08</time>
+    </dt>
+    <dd>Added links to GC-AEM, CDTS and Drupal WxT implementation guidance</dd>
+    <dt>
+      <time datetime="2022-12-23" class="link-muted">2022-12-23</time>
+    </dt>
+    <dd>Added links to the research summary and blog post for the Wayfinding project</dd>
+    <dt>
+      <time datetime="2022-11-30" class="link-muted">2022-11-30</time>
+    </dt>
+    <dd>Added guidance for this new pattern</dd>
+  </dl>
+</section>
+<section>
+  <h2 id="discuss">Discussion</h2>
+  <ul>
+    <li><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the pattern in GitHub
+      issues</a></li>
+    <li><a href="https://design-gc-conception.slack.com/join/shared_invite/enQtODE1OTc5Mzg5NzQ4LWQ3MjZjMTdjMjk2ZTZmMTJjYWQ3ZmRiNDYwYjRmN2NjYzQyNjFlNDBlY2FkNWE1ODg2YjExY2QwZmVjN2MwMGM">Join the conversation on Slack</a></li>
+    <li><a href="mailto:{{ site.emails.dto }}">Send an email to the Digital Transformation Office</a></li>
+  </ul>
+</section>

--- a/common-design-patterns/site-footer-main.md
+++ b/common-design-patterns/site-footer-main.md
@@ -1,0 +1,206 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/pied-page-principale.html"
+date: 2022-11-30
+dateModified: 2023-04-06
+description: "The requirements listed in this design manual apply to departments and other portions of the federal public administration as set out in Schedules I, I.1 and II of the Financial Administration Act. As such, in-scope institutions must apply Canada.ca design requirements for all public-facing web sites or digital services."
+title: "Global footer: Main band"
+---
+<p><strong>Last updated</strong>: {{ page.dateModified }}</p>
+<p><span class="label label-danger">Mandatory on standard pages</span></p>
+<p>The main footer band is the primary element of the global footer. It provides links to the Government of Canada All contacts
+  page, the directory of departments and agencies and the About government theme page. It also provides links to all the
+  theme pages within Canada.ca.</p>
+<p><strong>2022 design update</strong>: We’ve recently updated this pattern as part of a new navigation strategy coming
+  out of the Wayfinding research project. To find out more about this project, visit the <a href="#research">Research and rationale</a> section on this page.</p>
+<div class="pattern-demo mrgn-tp-lg"><img src="../../images/footer-main-crop.jpg" class="img-responsive" alt=""></div>
+<section>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#use">When to use</a></li>
+    <li><a href="#avoid">What to avoid</a></li>
+    <li><a href="#design">Content and design</a></li>
+    <li><a href="#implement">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#latest">Latest changes</a></li>
+    <li><a href="#discuss">Discussion</a></li>
+  </ul>
+</section>
+<h2 id="use">When to use</h2>
+<p>The main footer band is a <strong>mandatory element</strong> for <strong>all standard pages</strong> from the Government of Canada.</p>
+<p>It’s optional for transactional and campaign pages.</p>
+<h2 id="avoid">What to avoid</h2>
+<p>Don’t adjust links or content in the main band. It should stay consistent across the Government of Canada web
+  presence. For links that are specific to an organization or program, use the <a href="./site-footer-contextual.html">contextual band</a>.</p>
+<h2 id="design">Content and design</h2>
+<h3>Content specifications</h3>
+<p>There are 2 groups of links in the main band, separated by a short dividing bar.</p>
+<p>Global links:</p>
+<ul>
+  <li>All contacts</li>
+  <li>Departments and agencies</li>
+  <li>About government</li>
+</ul>
+<p>Theme links in the following order:</p>
+<ul>
+  <li>Jobs</li>
+  <li>Immigration and citizenship</li>
+  <li>Travel and tourism</li>
+  <li>Business</li>
+  <li>Benefits</li>
+  <li>Health</li>
+  <li>Taxes</li>
+  <li>Environment and natural resources</li>
+  <li>National security and defence</li>
+  <li>Culture, history and sport</li>
+  <li>Policing, justice and emergencies</li>
+  <li>Transport and infrastructure</li>
+  <li>Canada and the world</li>
+  <li>Money and finance</li>
+  <li>Science and innovation</li>
+  <li>Indigenous peoples</li>
+  <li>Veterans and military</li>
+  <li>Youth</li>
+</ul>
+<h3>Design specifications</h3>
+<ul>
+  <li>Background colour: Primary accent colour (#26374a)</li>
+  <li>Text colour: white (#FFFFFF)</li>
+  <li>Font family:
+    <ul>
+      <li>header: Lato</li>
+      <li>links: Noto Sans</li>
+    </ul>
+  </li>
+  <li>Text size (base size for the footer is 16px):
+    <ul>
+      <li>header: 19px or 1.2em</li>
+      <li>links: 14px or 0.875em</li>
+    </ul>
+  </li>
+  <li>Font weight:
+    <ul>
+      <li>header: 700 or bold</li>
+      <li>links: 400 or regular</li>
+    </ul>
+  </li>
+  <li>Silhouette image of parliament set to the lower right</li>
+  <li>Columns: 3 column in large and medium screen formats, 1 column in small screen format</li>
+</ul>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-bttm-md">
+  <figure class="mrgn-bttm-lg">
+    <figcaption><b>Main band – large screen</b></figcaption>
+    <img src="../../images/footer-main.jpg" class="img-responsive"
+				alt="Diagram of main band for large screens. Text version below:">
+    <details>
+      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+      <p>On large screens the main band is arranged in 3 columns and contains links to “All contacts,” “Departments and agencies,” and “About government.” There is a small decorative line as a break before continuing with links to all themes and audiences.</p>
+    </details>
+  </figure>
+</div>
+<div class="pattern-demo">
+  <figure class="mrgn-bttm-lg">
+    <figcaption><b>Main band – small screen</b></figcaption>
+    <img src="../../images/footer-main-mobile.jpg" class="img-responsive"
+				alt="Diagram of main band for small screens. Text version below:">
+    <details>
+      <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+      <p>On small screens the main band is arranged in a single column and contains links to “All contacts,” “Departments and agencies,” and “About government.” There is a small decorative line as a break before continuing with links to all themes and audiences.</p>
+    </details>
+  </figure>
+</div>
+<section>
+  <h2 id="implement">How to implement</h2>
+  <h3>GCweb (WET) theme implementation reference</h3>
+  <h4>Default</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+  </ul>
+  <h4>Alternate options for standard pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/footers-en.html">Complete footer (contextual, main and sub-footer bands)</a></li>
+  </ul>
+  <h4>Alternate options for transactional or campaign pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-main-en.html">Main band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-main-en.html">Contextual band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-contextual-en.html">Contextual band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-corporate-en.html">Sub-footer band only</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footers-en.html">Sub-footer band only with no optional links</a></li>
+  </ul>
+</section>
+<section>
+  <h3>Implementations</h3>
+  <p>Determine the footer configuration that best suits your needs for the type of page you're creating. Refer to your implementation's guidance to customize the contextual band or sub-footer band links.</p>
+  <div class="wb-tabs mrgn-tp-lg">
+    <div class="tabpanels">
+      <details id="004" open="open">
+        <summary><strong>GC-AEM</strong></summary>
+        <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+        <ul>
+          <li><a href="https://www.gcpedia.gc.ca/gcwiki/images/2/22/AEM-6.5-Documentation-Unit_3-1-1-_Customizing_Global_Footer.pdf">Customizing the Global footer (PDF - only available on the Government of Canada network)</a></li>
+          <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (only available on the Government of Canada network)</a></li>
+        </ul>
+      </details>
+      <details id="005">
+        <summary><strong>CDTS</strong></summary>
+        <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+        <ul>
+          <li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_47/cdts/samples/footer-en.html">Complete footer (contextual, main, sub-footer bands)</a></li>
+          <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+        </ul>
+      </details>
+      <details id="006">
+        <summary><strong>Drupal WxT</strong></summary>
+        <p class="mrgn-tp-lg">For Drupal WxT:</p>
+        <ul>
+          <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+        </ul>
+        <p>2023 footer update:</p>
+        <ul>
+          <li><a href="https://github.com/drupalwxt/wxt/releases/tag/4.4.1">Drupal WxT (4.4.1) release notes</a></li>
+          <li><a href="https://drupalwxt.github.io/en/docs/general/update/">Drupal WxT update process</a></li>
+        </ul>
+      </details>
+    </div>
+  </div>
+</section>
+<section>
+  <h2 id="research">Research and rationale</h2>
+  <p>We updated the global footer for Canada.ca to align with a new overall navigation strategy that came out of the
+    Wayfinding research project.</p>
+  <ul>
+    <li><a href="{{ site.url }}/research-summaries/wayfinding-on-canada-ca">Wayfinding on Canada.ca research summary</a><br>
+      This summary explains the context of the research and the insights that drove the design updates.</li>
+    <li><a href="https://blog.canada.ca/2022/12/21/wayfinding-research-project">Wayfinding research project improves our approach to navigation on Canada.ca</a><br>
+      This blog post explains the changes that are being made to the Canada.ca design, and how they are being implemented.</li>
+  </ul>
+</section>
+<section>
+  <h2 id="latest">Latest changes</h2>
+  <dl class="dl-horizontal">
+    <dt>
+      <time datetime="2023-02-08" class="link-muted">2023-02-08</time>
+    </dt>
+    <dd>Added links to GC-AEM, CDTS and Drupal WxT implementation guidance</dd>
+    <dt>
+      <time datetime="2022-12-23" class="link-muted">2022-12-23</time>
+    </dt>
+    <dd>Added links to the research summary and blog post for the Wayfinding project</dd>
+    <dt>
+      <time datetime="2022-11-30" class="link-muted">2022-11-30</time>
+    </dt>
+    <dd>Created a new page for guidance specific to this band, updated content specifications to adjust global links and include
+      theme links, added design specifications and provided implementation resources</dd>
+  </dl>
+</section>
+<section>
+  <h2 id="discuss">Discussion</h2>
+  <ul>
+    <li><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the pattern in GitHub
+      issues</a></li>
+    <li><a href="https://design-gc-conception.slack.com/join/shared_invite/enQtODE1OTc5Mzg5NzQ4LWQ3MjZjMTdjMjk2ZTZmMTJjYWQ3ZmRiNDYwYjRmN2NjYzQyNjFlNDBlY2FkNWE1ODg2YjExY2QwZmVjN2MwMGM">Join the conversation on Slack</a></li>
+    <li><a href="mailto:{{ site.emails.dto }}">Send an email to the Digital Transformation Office</a></li>
+  </ul>
+</section>

--- a/common-design-patterns/site-footer-sub.md
+++ b/common-design-patterns/site-footer-sub.md
@@ -1,0 +1,209 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/pied-page-sous.html"
+date: 2022-11-30
+dateModified: 2023-04-06
+description: "This is a mandatory element of the global (site-wide) footer."
+title: "Global footer: Sub-footer band"
+---
+<p><strong>Last updated</strong>: {{ page.dateModified }}</p>
+<section>
+  <p><span class="label label-danger">Mandatory</span></p>
+  <p>The sub-footer band is a secondary element of the global footer. It contains a series of corporate links and the Canada wordmark.</p>
+  <p><strong>2022 design update</strong>: We’ve recently updated this pattern as part of a new navigation strategy coming
+    out of the Wayfinding research project. To find out more about this project, visit the <a href="#research">Research and rationale</a> section on this page.</p>
+  <div class="pattern-demo"> <img src="../../images/footer-sub-crop.jpg" class="img-responsive"
+				alt=""> </div>
+  <h2>On this page</h2>
+  <ul>
+    <li><a href="#use">When to use</a></li>
+    <li><a href="#design">Content and design</a></li>
+    <li><a href="#implement">How to implement</a></li>
+    <li><a href="#research">Research and rationale</a></li>
+    <li><a href="#latest">Latest changes</a></li>
+    <li><a href="#discuss">Discussion</a></li>
+  </ul>
+  <h2 id="use">When to use</h2>
+  <p>The sub-footer band is mandatory on all page types.</p>
+  <h2 id="design">Content and design</h2>
+  <h3>Content specifications</h3>
+  <p>Links appear in the following order:</p>
+  <ul>
+    <li>Social media</li>
+    <li>Mobile applications</li>
+    <li>About Canada.ca</li>
+    <li>Terms and conditions - can be contextualized to link to the Terms and conditions of the department or program responsible for the content on that page</li>
+    <li>Privacy - can be contextualized to link to the privacy information of the department or program responsible for the content on that page</li>
+  </ul>
+  <p>On <strong>transactional</strong> and <strong>campaign</strong> pages, you can omit the Social media, Mobile applications and About Canada.ca links.</p>
+  <p>On <strong>transactional</strong> pages, ensure that the Terms and conditions and Privacy links keep people within their current session (for authenticated applications, keep them within the application environment).</p>
+</section>
+<section>
+  <h4>Canada wordmark</h4>
+  <p>Include the Canada wordmark in the sub-footer band across all pages of Canada.ca. This serves to reinforce the brand and provide an additional cue to people that they are reading content from  the Government of Canada.</p>
+  <h3>Design specifications</h3>
+  <ul>
+    <li>Background colour: sub-footer grey (#F8F8F8)</li>
+    <li>Text colour: <a href="../styles/colours.html">standard link colours</a></li>
+    <li>Text size: 14 px or 0.875 em</li>
+    <li>Font: Noto Sans</li>
+    <li>Canada wordmark position: set to the right</li>
+    <li>Canada wordmark size: 40px height</li>
+    <li>Layout: 1 row in large screen format, 2 columns in medium screen format, 1 column in small screen format</li>
+  </ul>
+  <h3>Visual examples</h3>
+  <details>
+    <summary>Standard pages (desktop and mobile)</summary>
+    <div class="pattern-demo mrgn-bttm-md">
+      <figure class="mrgn-bttm-lg">
+        <figcaption><b>Sub-footer band – large screen</b></figcaption>
+        <img src="../../images/footer-sub.jpg" class="img-responsive"
+				alt="Diagram of sub-footer band for large screens. Text version below:">
+        <details>
+          <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+          <p>On large screens the sub-footer band contains links to “Social media,”
+            “Mobile applications,” “About Canada.ca,” “Terms and conditions,” and “Privacy,” all aligned to the left in a single
+            row. It also includes the Canada wordmark in the same row, aligned to the right.</p>
+        </details>
+      </figure>
+    </div>
+    <div class="pattern-demo">
+      <figure class="mrgn-bttm-lg">
+        <figcaption><b>Sub-footer band – small screen</b></figcaption>
+        <img src="../../images/footer-sub-mobile.jpg" class="img-responsive"
+				alt="Diagram of sub-footer band for small screens. Text version below:">
+        <details>
+          <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+          <p>On small screens the sub-footer band contains links to “Social media,”
+            “Mobile applications,” “About Canada.ca,” “Terms and conditions,” and “Privacy,” arranged in 2
+            columns. Below these links is a final row with the Canada wordmark aligned to the right.</p>
+        </details>
+      </figure>
+    </div>
+  </details>
+  <details>
+    <summary>Transactional and campaign pages (desktop and mobile)</summary>
+    <div class="pattern-demo mrgn-bttm-md">
+      <figure class="mrgn-bttm-lg">
+        <figcaption><b>Minimum sub-footer – large screen</b></figcaption>
+        <img src="../../images/footer-min-en.png" class="img-responsive"
+						alt="Diagram of minimum sub-footer for large screens. Text version below:">
+        <details>
+          <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+          <p>On large screens, the minimum sub-footer for transactional and campaign pages includes only the links
+            to “Terms and conditions” and “Privacy.” These are aligned to the left in a single row. It also
+            includes the Canada wordmark in the same row, aligned to the right.</p>
+        </details>
+      </figure>
+    </div>
+    <div class="pattern-demo">
+      <figure class="mrgn-bttm-lg">
+        <figcaption><b>Minimum sub-footer – small screen</b></figcaption>
+        <img src="../../images/footer-min-mobile-en.png" class="img-responsive"
+						alt="Diagram of minimum sub-footer for small screens. Text version below:">
+        <details>
+          <summary class="wb-toggle" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Text version</summary>
+          <p>On small screens, the minimum sub-footer for transactional and campaign pages includes only the
+            links to “Terms and conditions” and “Privacy.” Below these links is a final row with the Canada wordmark aligned to the right.</p>
+        </details>
+      </figure>
+    </div>
+  </details>
+</section>
+<section>
+  <h2 id="implement">How to implement</h2>
+  <h3>GCweb (WET) theme implementation reference</h3>
+  <h4>Default</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+  </ul>
+  <h4>Alternate options for standard pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/footers-en.html">Complete footer (contextual, main and sub-footer bands)</a></li>
+  </ul>
+  <h4>Alternate options for transactional or campaign pages</h4>
+  <ul>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-contextual-en.html">Main band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-main-en.html">Main band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footer-main-en.html">Contextual band and sub-footer band</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-contextual-en.html">Contextual band and sub-footer band with no optional links</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/only-footer-corporate-en.html">Sub-footer band only</a></li>
+    <li><a href="https://wet-boew.github.io/GCWeb/sites/footers/no-footers-en.html">Sub-footer band only with no optional links</a></li>
+  </ul>
+</section>
+<section>
+  <h3>Implementations</h3>
+  <p>Determine the footer configuration that best suits your needs for the type of page you're creating. Refer to your implementation's guidance to customize the contextual band or sub-footer band links.</p>
+  <div class="wb-tabs mrgn-tp-lg">
+    <div class="tabpanels">
+      <details id="004" open="open">
+        <summary><strong>GC-AEM</strong></summary>
+        <p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+        <ul>
+          <li><a href="https://www.gcpedia.gc.ca/gcwiki/images/2/22/AEM-6.5-Documentation-Unit_3-1-1-_Customizing_Global_Footer.pdf">Customizing the Global footer (PDF - only available on the Government of Canada network)</a></li>
+          <li><a href="https://www.gcpedia.gc.ca/wiki/AEM_GC-specific_Documentation_6.5">AEM/Managed Web Service documentation (only available on the Government of Canada network)</a></li>
+        </ul>
+      </details>
+      <details id="005">
+        <summary><strong>CDTS</strong></summary>
+        <p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+        <ul>
+          <li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_47/cdts/samples/footer-en.html">Complete footer (contextual, main, sub-footer bands)</a></li>
+          <li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+        </ul>
+      </details>
+      <details id="006">
+        <summary><strong>Drupal WxT</strong></summary>
+        <p class="mrgn-tp-lg">For Drupal WxT:</p>
+        <ul>
+          <li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+        </ul>
+        <p>2023 footer update:</p>
+        <ul>
+          <li><a href="https://github.com/drupalwxt/wxt/releases/tag/4.4.1">Drupal WxT (4.4.1) release notes</a></li>
+          <li><a href="https://drupalwxt.github.io/en/docs/general/update/">Drupal WxT update process</a></li>
+        </ul>
+      </details>
+    </div>
+  </div>
+</section>
+<section>
+  <h2 id="research">Research and rationale</h2>
+  <p>We updated the global footer for Canada.ca to align with a new overall navigation strategy that came out of the
+    Wayfinding research project.</p>
+  <ul>
+    <li><a href="{{ site.url }}/research-summaries/wayfinding-on-canada-ca">Wayfinding on Canada.ca research summary</a><br>
+      This summary explains the context of the research and the insights that drove the design updates.</li>
+    <li><a href="https://blog.canada.ca/2022/12/21/wayfinding-research-project">Wayfinding research project improves our approach to navigation on Canada.ca</a><br>
+      This blog post explains the changes that are being made to the Canada.ca design, and how they are being implemented.</li>
+  </ul>
+</section>
+<section>
+  <h2 id="latest">Latest changes</h2>
+  <dl class="dl-horizontal">
+    <dt>
+      <time datetime="2023-02-08" class="link-muted">2023-02-08</time>
+    </dt>
+    <dd>Added links to GC-AEM, CDTS and Drupal WxT implementation guidance</dd>
+    <dt>
+      <time datetime="2023-01-18" class="link-muted">2023-01-18</time>
+    </dt>
+    <dd>Clarified that on transactional pages, the Terms and conditions and Privacy links should keep people within their current session</dd>
+    <dt>
+      <time datetime="2022-12-23" class="link-muted">2022-12-23</time>
+    </dt>
+    <dd>Added links to the research summary and blog post for the Wayfinding project</dd>
+    <dt>
+      <time datetime="2022-11-30" class="link-muted">2022-11-30</time>
+    </dt>
+    <dd>Created a new page for guidance specific to this band, updated content specifications to include Canada wordmark, added design specifications and visual examples</dd>
+  </dl>
+</section>
+<section>
+  <h2 id="discuss">Discussion</h2>
+  <ul>
+    <li><a href="https://github.com/canada-ca/design-system-systeme-conception/issues">Discuss the pattern in GitHub
+      issues</a></li>
+    <li><a href="https://design-gc-conception.slack.com/join/shared_invite/enQtODE1OTc5Mzg5NzQ4LWQ3MjZjMTdjMjk2ZTZmMTJjYWQ3ZmRiNDYwYjRmN2NjYzQyNjFlNDBlY2FkNWE1ODg2YjExY2QwZmVjN2MwMGM">Join the conversation on Slack</a></li>
+    <li><a href="mailto:{{ site.emails.dto }}">Send an email to the Digital Transformation Office</a></li>
+  </ul>
+</section>

--- a/common-design-patterns/site-menu.md
+++ b/common-design-patterns/site-menu.md
@@ -1,0 +1,250 @@
+---
+altLangPage: "https://conception.canada.ca/configurations-conception-communes/menu-site.html"
+date: 2017-10-05
+dateModified: 2023-06-26
+description: "Guidance about using the theme and topic menu on Canada.ca. The theme and topic menu provides access to the top tasks from all Government of Canada websites grouped under the main themes of Canada.ca."
+title: "Theme and topic menu"
+---
+<div class="row">
+	<div class="col-md-12 pull-left">
+		<ul class="list-inline small mrgn-bttm-sm" id="list-inline-desktop-only">
+			<li class="mrgn-rght-lg"> Last updated: {{ page.dateModified }}</li>
+		</ul>
+	</div>
+</div>
+<p><span class="label label-danger">Mandatory on standard pages</span></p>
+<p>The theme and topic menu provides access to the top tasks from all Government of Canada websites grouped under the main themes of Canada.ca.</p>
+<div class="pattern-demo mrgn-tp-lg">
+	<figure class="mrgn-bttm-sm"><img src="../../images/01-theme-menu-flyout-en.png" class="img-responsive" alt=""></figure>
+</div>
+<section>
+	<h2>On this page</h2>
+	<ul>
+		<li><a href="#when">When to use</a></li>
+		<li><a href="#avoid">What to avoid</a></li>
+		<li><a href="#content">Content and design</a></li>
+		<li><a href="#implementation">How to implement</a></li>
+		<li><a href="#research">Research and rationale</a></li>
+		<li><a href="#changes">Latest changes</a></li>
+	</ul>
+</section>
+<h2 id="when">When to use</h2>
+<p><strong>2023 design update</strong>: We’ve recently updated this pattern as part of a new navigation strategy coming out of the Wayfinding research project. The theme and topic menu is in transition. To find out more about this project, visit the <a href="#research">Research and rationale</a> section on this page. </p>
+<h3>Current situation</h3>
+<p>Apply the theme and topic menu as follows:</p>
+<ul>
+	<li><strong>campaign pages</strong> optional</li>
+	<li><strong>transactional pages</strong> optional but not recommended</li>
+	<li><strong>theme and topic pages</strong> mandatory</li>
+</ul>
+<p>On <strong>standard destination pages</strong> and <strong>institutional landing pages</strong>, the theme and topic menu is mandatory until ALL the following conditions are met:</p>
+<ul>
+	<li>the page has the 2023 <a href="site-footer.html">global footer</a></li>
+	<li>the menu regularly receives less than 1% of clicks within a group of related pages
+		<ul>
+			<li>if you’re adopting the design for the first time, you don’t need to add the menu</li>
+		</ul>
+	</li>
+	<li>you’ve added a <a href="contextual-signin.html">contextual Sign in button</a> where it’s relevant to the content</li>
+</ul>
+<p>A group of pages might be all the pages related to a specific program or service, or all the pages related to a single organization.</p>
+<h3>Future state</h3>
+<p>Eventually we will retire the theme and topic menu pattern. Links to the theme pages will remain available through the main band of the global footer and the breadcrumb trail.</p>
+<h2 id="avoid">What to avoid</h2>
+<p>Don’t repurpose the Theme and topic menu for other navigation. The menu is a global navigation tool. It’s confusing for users if it behaves differently depending on where they are in the site.</p>
+<p>Don’t remove it from standard destination pages before you meet the conditions above.</p>
+<p>Don’t change the style or colour scheme.</p>
+<p>Don’t put additional links or text in the flyout.</p>
+<h2 id="content">Content and design</h2>
+<p>The theme and topic menu consists of 3 integrated elements - the menu button which opens and closes the menu, the theme list that allows for choosing between themes, and the flyout that presents topics and most requested links for each theme.</p>
+<h3>Content specifications</h3>
+<ol>
+	<li>Menu button:
+		<ul>
+			<li>label is “<span class="text-uppercase">Menu</span>” with a downwards caret</li>
+		</ul>
+	</li>
+	<li class="mrgn-tp-lg">Theme list, which includes the 15 main Canada.ca themes in the following order:
+		<ul>
+			<li>Jobs and the workplace</li>
+			<li>Immigration and citizenship</li>
+			<li>Travel and tourism</li>
+			<li>Business and industry</li>
+			<li>Benefits</li>
+			<li>Health</li>
+			<li>Taxes</li>
+			<li>Environment and natural resources</li>
+			<li>National security and defence</li>
+			<li>Culture, history and sport</li>
+			<li>Policing, justice and emergencies</li>
+			<li>Transport and infrastructure</li>
+			<li>Canada and the world</li>
+			<li>Money and finances</li>
+			<li>Science and innovation</li>
+		</ul>
+	</li>
+	<li class="mrgn-tp-lg">Flyout:
+		<p>Hovering or clicking on one of the 15 themes reveals a flyout containing:</p>
+		<ul>
+			<li>a link to the landing page for the theme itself</li>
+			<li>first-level topics within that theme</li>
+			<li>Most requested links based on the highest demand items for that theme</li>
+		</ul>
+	</li>
+</ol>
+<p>Topics and Most requested links should appear in the same order on both the menu and the theme page.</p>
+<h4>Interactions</h4>
+<h5>Large screens</h5>
+<ul>
+	<li>Clicking on the menu button expands the theme list element with the Jobs flyout open</li>
+	<li>Once opened, hovering or clicking on one of the 15 themes reveals a flyout for that theme</li>
+	<li>Clicking on the menu a second time closes it</li>
+</ul>
+<h5>Small screens</h5>
+<ul>
+	<li>Tapping the menu button expands the theme list as a series of submenu options</li>
+	<li>Tapping any theme option expands the list of topics for that theme and reveals another submenu option for the Most requested</li>
+	<li>Tapping the Most requested option expands the list of most requested links for that theme</li>
+	<li>Tapping any expanded item again will close it</li>
+</ul>
+<h3>Design specifications</h3>
+<ol>
+	<li>Menu button styles:
+		<ul>
+			<li>Background colour: primary accent colour (#26374a)</li>
+			<li>Text colour: white (#FFFFFF)</li>
+			<li>Text size: 20px or 1em</li>
+			<li>Font: Noto Sans</li>
+		</ul>
+		<p>Note: The homepage of Canada.ca uses different styling for the menu button. That styling is reserved for the homepage only.</p>
+	</li>
+	<li class="mrgn-tp-lg">Theme list styles:
+		<ul>
+			<li>Background colour: #444</li>
+			<li>Text colour: white (#FFF)</li>
+			<li>Background colour selected: #FFF</li>
+			<li>Text colour when selected: dark grey (#333)</li>
+			<li>Text size: 18px</li>
+			<li>Font: Noto Sans</li>
+		</ul>
+	</li>
+	<li class="mrgn-tp-lg">Flyout styles:
+		<ul>
+			<li>Background colour: primary accent colour (#FFF)</li>
+			<li>Text colour: white (#284162)</li>
+			<li>Text size: 18px</li>
+			<li>Text size theme title: 32px</li>
+			<li>Font: Noto Sans</li>
+		</ul>
+	</li>
+</ol>
+<h4>Accessibility</h4>
+<p>Style the menu button label as capital letters, but write the label in sentence case (Menu), so screen readers don't read each letter individually.</p>
+<h3>Visual examples</h3>
+<div class="pattern-demo mrgn-tp-lg">
+	<figure>
+		<figcaption><b>Theme and topic menu with flyout open - large screen</b></figcaption>
+		<img src="../../images/01-theme-menu-flyout-en.png" class="img-responsive" alt=" ">
+		<details class="mrgn-tp-md">
+			<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: theme and topic menu with flyout open - large screen</summary>
+			<p class="mrgn-tp-lg">The theme and topic menu consists of a button with the word "Menu" and a downward-facing chevron. When clicked, it expands to a menu that exposes the titles of all 15 themes. When the title of a theme is clicked a menu flyout appears on the right-hand side of the theme menu. The theme title is featured prominently at the top of the flyout while the main topics are listed below the title on the left-hand side. On the right-hand side of the flyout there is a "Most requested" heading followed by a list of the most requested tasks.</p>
+		</details>
+	</figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+	<figure>
+		<figcaption><b>Theme and topic menu – small screen</b></figcaption>
+		<img src="../../images/01-menu-mobile-closed-en.png" class="img-responsive" alt=" ">
+		<details class="mrgn-tp-md">
+			<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: theme and topic menu  - small screen</summary>
+			<p class="mrgn-tp-lg">The theme and topic menu consists of a button with the word "Menu" and a downward-facing chevron. When clicked, it expands to a menu that exposes the titles of all 15 themes. When the title of a theme is clicked a menu flyout appears on the right-hand side of the theme menu. The theme title is featured prominently at the top of the flyout while the main topics are listed below the title on the left-hand side. On the right-hand side of the flyout there is a "Most requested" heading followed by a list of the most requested tasks.</p>
+		</details>
+	</figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+	<figure>
+		<figcaption><b>Theme and topic submenu open – small screen</b></figcaption>
+		<img src="../../images/01-menu-mobile-open-en.png" class="img-responsive" alt=" ">
+		<details class="mrgn-tp-md">
+			<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: theme and topic submenu open – small screen</summary>
+			<p class="mrgn-tp-lg">The theme and topic menu consists of a button with the word "Menu" and a downward-facing chevron. When clicked, it expands to a menu that exposes all themes. The "Travel and tourism"  theme is expanded. It has a downwards-facing chevron to the left of the title "Travel and tourism". Below that title is a box with the words "Travel: home". Below that are links to the other topics within the theme. At the end of the expanded menu is another box with a sideways-facing chevron and a "Most requested" heading.</p>
+		</details>
+	</figure>
+</div>
+<div class="pattern-demo mrgn-tp-lg">
+	<figure>
+		<figcaption><b>Theme and topic menu with most requested submenu open - small screen</b></figcaption>
+		<img src="../../images/01-menu-mobile-mr-en.png" class="img-responsive mrgn-tp-md" alt=" ">
+		<details class="mrgn-tp-md">
+			<summary class="wb-toggle small" data-toggle="{&quot;print&quot;:&quot;on&quot;}">Image description: theme and topic menu with most requested submenu open - small screen</summary>
+			<p class="mrgn-tp-lg">The "Most requested" menu is expanded. It has a downwards-facing chevron to the left of the words "Most requested". Underneath this heading are links to the 7 most requested pages for that theme.</p>
+		</details>
+	</figure>
+</div>
+<h2 id="implementation">How to implement</h2>
+<p>Find working examples and code for implementing the theme and topic menu.</p>
+<h3>GCweb (WET) theme implementation reference</h3>
+<p>The implementation reference includes how to configure each element of the header.</p>
+<ul>
+	<li><a href="https://wet-boew.github.io/GCWeb/sites/gcweb-menu/gcweb-menu-docs-en.html">Theme and topic menu</a></li>
+	<li><a href="https://wet-boew.github.io/GCWeb/sites/header/header-docs-en.html">GCWeb (WET) header documentation</a></li>
+</ul>
+<h3>Implementations</h3>
+<p>Determine what best suits the type of page you're creating. Refer to your implementation's guidance if you want to exclude breadcrumbs.</p>
+<div class="row">
+	<div class="col-md-8">
+		<div class="wb-tabs mrgn-tp-lg">
+			<div class="tabpanels">
+				<details id="004" open="open">
+					<summary><strong>GC-AEM</strong></summary>
+					<p class="mrgn-tp-lg">For the Government of Canada Adobe Experience Manager (AEM):</p>
+					<ul>
+						<li><a href="https://www.gcpedia.gc.ca/gcwiki/images/9/9a/AEM-6.5-Documentation-Unit-3-7-Changing-the-Default-Breadcrumb.pdf">Changing the default breadcrumb (PDF - GCPedia link - only available on the Government of Canada network)</a></li>
+					</ul>
+				</details>
+				<details id="005">
+					<summary><strong>CDTS</strong></summary>
+					<p class="mrgn-tp-lg">For the Centrally Deployed Templates Solution (CDTS):</p>
+					<ul>
+						<li><a href="https://cdts.service.canada.ca/app/cls/WET/gcweb/v4_0_47/cdts/samples/breadcrumbs-en.html">Breadcrumbs - CDTS documentation </a></li>
+						<li><a href="https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html">CDTS documentation</a></li>
+					</ul>
+				</details>
+				<details id="006">
+					<summary><strong>Drupal WxT</strong></summary>
+					<p class="mrgn-tp-lg">For Drupal WxT:</p>
+					<ul>
+						<li><a href="https://drupalwxt.github.io/">Drupal WxT documentation</a></li>
+					</ul>
+				</details>
+			</div>
+		</div>
+	</div>
+</div>
+<h2 id="research">Research and rationale</h2>
+<p>Consult research findings and policy rationale.</p>
+<h3>Research findings</h3>
+<ul>
+<li>
+  <a href="https://blog.canada.ca/2020/08/10/CanadaDotCa-trusted-source.html">Canada.ca is a trusted source</a>
+  <br>Explains the decision to use “Canada.ca” as the label for the first link in the breadcrumb
+</li>
+<li>
+  <a href="{{ site.url }}/research-summaries/wayfinding-on-canada-ca.html">Wayfinding on Canada.ca research summary</a>
+  <br>Research showing that people navigating on the site use breadcrumb links nearly twice as often as they use the Theme and topic menu</li>
+</ul>
+
+<h3>Policy rationale</h3>
+<p>The spacing specifications for the breadcrumb links are designed so that touch targets meet WCAG AAA requirements.</p>
+<p>As part of the global header, the breadcrumb is a mandatory element under the <cite>Canada.ca Specifications.</cite></p>
+<ul>
+  <li><a href="https://design.canada.ca/specifications/mandatory-elements.html">Mandatory elements of the design system</a></li>
+</ul>
+
+<h2 id="changes">Latest changes</h2>
+<dl class="dl-horizontal">
+  <dt>
+    <time datetime="2023-06-26" class="link-muted">2023-06-26</time>
+  </dt>
+  <dd>Updated the guidance to include advice on what to avoid, content and design specifications, visual examples, implementation guidance, research findings and policy rationale</dd>
+</dl>


### PR DESCRIPTION
Move files one directory lower to harmonize with production site structure.
On the repo these files are in /common-design-patterns/global-footer and ../global-header directories. However, on Netlify production file structure, these subdirectories do not exist. The files are located in the /common-design-patterns folder instead.
This move simply harmonizes the repo with the production site.