### PR TITLE
Update Gemfile.lock to include Jekyll version 4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ DEPENDENCIES
   base64
   bigdecimal
   csv
+  jekyll (~> 4.3)
   jekyll-remote-theme!
   logger
   rake (>= 0.a)


### PR DESCRIPTION
Add Jekyll version constraint to the Gemfile.lock to ensure compatibility with the project.

## Alternate language PR
- https://github.com/canada-ca/systeme-conception/pull/451