### PR TITLE
Revert decommissioning of service initiation page pattern

### DIFF
--- a/ajax/patterns-01-en.json
+++ b/ajax/patterns-01-en.json
@@ -1184,8 +1184,8 @@
   }, {
     "NAME": "<a href=\"{{ site.url }}/recommended-templates/service-initiation-pages.html\">Service initiation page</a>",
     "SOURCE": "Template and pattern library",
-    "DESCRIPTION": "We’re decommissioning this pattern. Gives people the information they need before starting the task, such as explaining eligibility criteria or steps to follow",
-    "WHENTOUSE": "We’re decommissioning this pattern. Gives people the information they need before starting the task, such as explaining eligibility criteria or steps to follow. Gives people easy access to service standards, turnaround times, related services, guides and help.",
+    "DESCRIPTION": "Gives people the information they need before starting the task, such as explaining eligibility criteria or steps to follow",
+    "WHENTOUSE": "Gives people the information they need before starting the task, such as explaining eligibility criteria or steps to follow. Gives people easy access to service standards, turnaround times, related services, guides and help.",
     "CATEGORY": "Template",
     "TYPE": "Destination, Navigation",
     "MANDATORY": "No",

--- a/recommended-templates/service-initiation-pages.md
+++ b/recommended-templates/service-initiation-pages.md
@@ -1,338 +1,666 @@
 ---
 altLangPage: https://conception.canada.ca/modeles-recommandes/pages-lancement-service.html
-date: 2018-12-19
-dateModified: 2025-11-28
+dateModified: '2018-12-19'
 description: null
-title: "No longer supported: Service initiation pages template"
-titleH1: "Service initiation pages template"
+title: "Service initiation pages template"
 ---
-<section class="alert alert-info">
-  <h2>Information</h2>
-  <p>This is an older template that may be decommissioned in 2026. Consider using the <a href="https://design.canada.ca/common-design-patterns/subway-navigation.html">subway navigation design pattern</a> instead.</p>
-</section>
 
-<p>Service initiation pages focus on helping Canada.ca visitors start a task. For some tasks, these pages allow for task completion as well.</p>
-<p>While many services involve transactions or an exchange of information between people and program administrators through forms, information may also be considered a service. For example, weather statements, food guides and product safety recalls all provide outcomes for people just as an online form would.</p>
-<p>Service initiation pages:</p>
-<ul>
-  <li>support a consistent approach to task initiation and completion, including ordering by steps where required</li>
-  <li>provide people with the information they need before initiating the task offer alternate methods, where applicable, of completing a service; including online, in-person or by mail</li>
-  <li>ensure that experienced clients (those who have previously used a particular service) can quickly initiate a task and choose whether or not to review all of the supporting information offered</li>
-</ul>
-<section>
-  <h2>On this page</h2>
-  <ul>
-    <li><a href="#use">When to use this template</a></li>
-    <li><a href="#specifications">How to use this template</a></li>
-    <li><a href="#navigation">User navigation</a></li>
-    <li><a href="#latest-changes">Latest changes</a></li>
-  </ul>
-</section>
-<section>
-  <h2 id="use">When to use this template</h2>
-  <ul>
-    <li>Use to initiate a single, standalone task that points to any service delivery channel such as phone, email, mail, etc.</li>
-    <li>Use to start tasks that support services (as defined under the <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603">Policy on Service and Digital</a>)</li>
-    <li>Use to start tasks that have prerequisites to satisfy before starting the task (such as eligibility criteria or having documents or information in hand)</li>
-    <li>Don’t use for tasks that do not have any prerequisites</li>
-  </ul>
-</section>
-<section>
-  <h2 id="specifications">How to use this template</h2>
-  <div class="btn-group mrgn-bttm-sm">
-    <button class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#template-elements", "type": "on"}' type="button">Expand All</button>
-    <button class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#template-elements", "type": "off"}' type="button">Collapse All</button>
-  </div>
-  <div class="row">
-    <div class="col-lg-6 pull-right">
-      <figure class="mrgn-bttm-lg">
-        <figcaption class="text-center"><b>Service initiation page template</b></figcaption>
-        <img alt="Template of service initiation page single step with contact and more information showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below." class="full-width" src="../images/service-initiation-eng.jpg" />
-      </figure>
-      <figure class="mrgn-bttm-lg">
-        <figcaption class="text-center"><b>Service initiation page template: single step, with contact and “more information”</b></figcaption>
-        <img alt="Template of service initiation page single step with contact and more information showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below." class="full-width" src="../images/service-initiation-simpler-eng.jpg" />
-      </figure>
-      <figure class="mrgn-bttm-lg">
-        <figcaption class="text-center"><b>Service initiation page template: single step only</b></figcaption>
-        <img alt="Template of service initiation page single step only showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below." class="full-width" src="../images/service-initiation-simplest-eng.jpg" />
-      </figure>
-    </div>
-    <div class="col-lg-6 pull-left">
-      <section id="template-elements">
-        <section>
-          <h3>1: Service/task name</h3>
-          <p>Presents the name of the service/task and the currently selected step</p>
-          <ul class="list-unstyled">
-            <li id="element2">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>the service/task name must be a unique H1</li>
-                  <li>must be the first component on the page</li>
-                  <li>for all steps, the service/task name should use the following convention:
-                    <ul>
-                      <li>[Service/task name]: Step #. [Step name]</li>
-                      <li>for example, Apply for Employment Insurance: Step 2. Eligibility</li>
-                    </ul>
-                  </li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>2: Institutional byline</h3>
-          <p>Provides a link to the institution, organization or partnering/collaborative arrangement entity responsible for the content of the page</p>
-          <ul class="list-unstyled">
-            <li id="element4">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>use the Institutional byline pattern</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>3: Service steps</h3>
-          <p>Shows links to each step in initiating the service and highlights the currently selected step</p>
-          <ul class="list-unstyled">
-            <li id="element5">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>use to start tasks that involve complex processes (for example, applying for a grant or funding, registering a business, etc.) or that include detailed prerequisites prior to starting the task (for example, eligibility criteria that must be met, or documents or information that must be in hand)</li>
-                  <li>label the sequence of steps similar to the tone and wording used in the following example:
-                    <ol>
-                      <li>What this service offers</li>
-                      <li>Who is eligible</li>
-                      <li>What you need before you start</li>
-                      <li>How to apply</li>
-                      <li>After you apply</li>
-                    </ol>
-                    <ul>
-                      <li>Contact us for help</li>
-                      <li>More information (background info, related tasks, etc.)</li>
-                    </ul>
-                  </li>
-                  <li>when additional unordered pages are included (for example, “more information”):
-                    <ul>
-                      <li>they should not include any information necessary for completing steps in the primary task sequence</li>
-                      <li>they should always appear after the numbered steps</li>
-                      <li>they should not be numbered</li>
-                    </ul>
-                  </li>
-                  <li>or, for simpler, single-step tasks with additional unordered (not numbered) pages, drop the numbers and label pages more like this:
-                    <ul>
-                      <li>How to apply</li>
-                      <li>Contact us for help</li>
-                      <li>More information (background info, related tasks, etc.)</li>
-                    </ul>
-                  </li>
-                </ul>
-              </details>
-            </li>
-            <li id="element6">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>appears below the institutional byline</li>
-                  <li>the <a href="../common-design-patterns/ordered-multipage.html">Ordered multi-page navigation pattern</a> is used to present service steps</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>4. Service content</h3>
-          <p>Provides pertinent details about the current step in the service</p>
-          <ul class="list-unstyled">
-            <li id="element7">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>content for each step must be complete and avoid the use of hyperlinks out of the current sequence to avoid disrupting the task flow.
-                    <ul>
-                      <li>if you must include links to additional information, use a dismissible overlay or a collapsible details/summary element to keep people inside the service initiation page set</li>
-                    </ul>
-                  </li>
-                  <li>on pages describing eligibility criteria, consider using the <a href="../common-design-patterns/interactive-questions.html">Interactive questions pattern</a> to make the requirements more easily understood</li>
-                  <li>keep text short and concise</li>
-                  <li>written for a grade 6-8 reading level</li>
-                </ul>
-              </details>
-            </li>
-            <li id="element8">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>appears below the service steps</li>
-                  <li>do not hyphenate words at the end of lines; retain ragged right edge for paragraphs and other text blocks</li>
-                  <li>use Common design patterns for destination content</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>5: Service standards and performance status</h3>
-          <p>Provides service standards people can reasonably expect to encounter under normal circumstances, and indicates the current real-time performance status of the service, whether performing as expected or not</p>
-          <ul class="list-unstyled">
-            <li id="element9">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>introduce service standards with a plain language heading that focuses on what people can reasonably expect under normal circumstances. Speak directly to a person. Examples:
-                    <ul>
-                      <li>“How long it will take to process your application”</li>
-                      <li>Application processing time”</li>
-                    </ul>
-                  </li>
-                  <li>include the current standard, the current performance status, how often the report is updated, and when current performance status was last updated. Example:
-                    <ul>
-                      <li>
-                        <p>"Our standard is to process applications in 30 business days. Applications are currently being processed in 17 business days.</p>
-                        <p>Current processing time is updated daily - last update January 31, 2020."</p>
-                      </li>
-                    </ul>
-                  </li>
-                  <li>you can use colour to add additional information about the status. Green (#278400) can be used to indicate that the current performance status is within the standard, and red (#D3080C) to indicate that it is not meeting the standard. (You must also indicate the current performance standard in text.)</li>
-                  <li>written for a grade 6-8 reading level</li>
-                  <li>keep text short and concise</li>
-                  <li>this component is intended to meet the <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603">Policy on Service and Digital</a> requirement to provide service standards on Canada.ca</li>
-                  <li>the <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=28422">Guideline on Service Management</a> contains definitions, characteristics and examples of service standards</li>
-                </ul>
-              </details>
-            </li>
-            <li id="element10">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>appears on pages where people will initiate the service (for example, How to apply) and post-application pages (for example, After you apply)</li>
-                  <li>appears for each available channel service/task (for example, in “Other ways to apply”)</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>6: Disclaimer</h3>
-          <p>Provides a link to the service’s terms of use</p>
-          <ul class="list-unstyled">
-            <li id="element11">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>use this component if there are applicable terms of use (for example, legal disclaimer, privacy policy)</li>
-                  <li>written for a grade 6-8 reading level</li>
-                </ul>
-              </details>
-            </li>
-            <li id="element12">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>appears directly above the initiation button/link</li>
-                  <li>use the <a href="../common-design-patterns/disclaimer-overlay.html">Disclaimer overlay pattern</a> pattern</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>7: Initiation button/link</h3>
-          <p>Serves as a link to the digital service</p>
-          <ul class="list-unstyled">
-            <li id="element13">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>provides a link to initiate digital service or a download</li>
-                  <li>use only once in the sequence of steps for the current task/service</li>
-                </ul>
-              </details>
-            </li>
-            <li id="element14">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>use the <a href="../common-design-patterns/buttons.html">Buttons</a> pattern or the <a href="../common-design-patterns/download-links.html">Download links</a> pattern</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>8: Other ways to access the service</h3>
-          <p>Provides alternative channels available to access this service, as well as associated service standards and performance status</p>
-          <ul class="list-unstyled">
-            <li id="element15">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>provides contact details, service standards and service status messages for all alternative channels (for example, in-person, telephone and mail options) available to access this service</li>
-                  <li>for each alterative channel, include contact information preceded by the applicable service standard and service status messages</li>
-                  <li>limit service standards associated with each alternative channel to 1 or 2 sentences</li>
-                  <li>written for a grade 6-8 reading level</li>
-                </ul>
-              </details>
-            </li>
-            <li id="element16">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>appears below the initiation link</li>
-                  <li>heading is labelled “Other ways to [apply]”</li>
-                  <li>subheadings include options like “By phone”, “In person”, and “By mail”</li>
-                  <li>may appear inside a collapsible details/summary element when alternate channels represent a small proportion of demand for this service</li>
-                </ul>
-              </details>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h3>9: Previous/next links</h3>
-          <p>Provides a means to navigate to the next or previous page from the bottom of a page</p>
-          <ul class="list-unstyled">
-            <li id="element17">
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Content</strong></summary>
-                <ul>
-                  <li>use this component if the service steps pattern is also being used</li>
-                </ul>
-              </details>
+<div>
+    <section>
+        <p>
+            Service initiation pages focus on helping Canada.ca visitors start a task. For some tasks, these pages allow for task completion as well.
+        </p>
+        <p>
+            While many services involve transactions or an exchange of information between people and program administrators through forms, information may also be considered a service. For example, weather statements, food guides and
+            product safety recalls all provide outcomes for people just as an online form would.
+        </p>
+        <p>
+            Service initiation pages:
+        </p>
+        <ul>
+            <li>
+                support a consistent approach to task initiation and completion, including ordering by steps where required
             </li>
             <li>
-              <details class="mrgn-bttm-sm">
-                <summary class="wb-toggle" data-toggle='{"print":"on"}'><strong>Presentation</strong></summary>
-                <ul>
-                  <li>go to <a href="../common-design-patterns/ordered-multipage.html">Ordered multi-page navigation pattern</a> for how to present previous/next links</li>
-                </ul>
-              </details>
+                provide people with the information they need before initiating the task offer alternate methods, where applicable, of completing a service; including online, in-person or by mail
             </li>
-          </ul>
+            <li>
+                ensure that experienced clients (those who have previously used a particular service) can quickly initiate a task and choose whether or not to review all of the supporting information offered
+            </li>
+        </ul>
+        <section>
+            <h2>
+                On this page
+            </h2>
+            <ul>
+                <li>
+                    <a href="#use">
+                        When to use this template
+                    </a>
+                </li>
+                <li>
+                    <a href="#specifications">
+                        How to use this template
+                    </a>
+                </li>
+                <li>
+                    <a href="#navigation">
+                        User navigation
+                    </a>
+                </li>
+            </ul>
         </section>
-      </section>
-    </div>
-  </div>
-</section>
-<section>
-  <h2 id="navigation">User navigation</h2>
-  <figure class="mrgn-bttm-lg">
-    <figcaption class="text-center"><b>User navigation diagram</b></figcaption>
-    <img alt="Diagram of how to navigate to service initiation pages on Canada.ca. Text version below:" class="img-responsive center-block" src="https://www.canada.ca/content//dam/tbs-sct/images/government-communications/canada-content-style-guide/service-initiation-pages-ia-eng.png" />
-    <details>
-      <summary class="wb-toggle" data-toggle='{"print":"on"}'>Text version</summary>
-      <p>Service initiation pages can be accessed from Canada.ca topic pages and institutional profiles pages.</p>
-    </details>
-  </figure>
-</section>
-<section>
-  <h2 id="latest-changes">Latest changes</h2>
-  <dl class="dl-horizontal">
-    <dt><time>2025-11-28</time></dt>
-    <dd>Added an alert to indicate that this pattern is scheduled for decommission.</dd>
-  </dl>
-</section>
+        <section>
+            <h2 id="use">
+                When to use this template
+            </h2>
+            <ul>
+                <li>
+                    Use to initiate a single, standalone task that points to any service delivery channel such as phone, email, mail, etc.
+                </li>
+                <li>
+                    Use to start tasks that support services (as defined under the
+                    <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603">
+                        Policy on Service and Digital
+                    </a>
+                    )
+                </li>
+                <li>
+                    Use to start tasks that have prerequisites to satisfy before starting the task (such as eligibility criteria or having documents or information in hand)
+                </li>
+                <li>
+                    Don’t use for tasks that do not have any prerequisites
+                </li>
+            </ul>
+        </section>
+        <section>
+            <h2 id="specifications">
+                How to use this template
+            </h2>
+            <div class="btn-group mrgn-bttm-sm">
+                <button class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#template-elements", "type": "on"}' type="button">
+                    Expand All
+                </button>
+                <button class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#template-elements", "type": "off"}' type="button">
+                    Collapse All
+                </button>
+            </div>
+            <div class="row">
+                <div class="col-lg-6 pull-right">
+                    <figure class="mrgn-bttm-lg">
+                        <figcaption class="text-center">
+                            <b>
+                                Service initiation page template
+                            </b>
+                        </figcaption>
+                        <img
+                            alt="Template of service initiation page single step with contact and more information showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below."
+                            class="full-width"
+                            src="../images/service-initiation-eng.jpg"
+                        />
+                    </figure>
+                    <figure class="mrgn-bttm-lg">
+                        <figcaption class="text-center">
+                            <b>
+                                Service initiation page template: single step, with contact and “more information”
+                            </b>
+                        </figcaption>
+                        <img
+                            alt="Template of service initiation page single step with contact and more information showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below."
+                            class="full-width"
+                            src="../images/service-initiation-simpler-eng.jpg"
+                        />
+                    </figure>
+                    <figure class="mrgn-bttm-lg">
+                        <figcaption class="text-center">
+                            <b>
+                                Service initiation page template: single step only
+                            </b>
+                        </figcaption>
+                        <img
+                            alt="Template of service initiation page single step only showing sections that make up its structure. Read top to bottom and left to right. Specifications detailed below."
+                            class="full-width"
+                            src="../images/service-initiation-simplest-eng.jpg"
+                        />
+                    </figure>
+                </div>
+                <div class="col-lg-6 pull-left">
+                    <section id="template-elements">
+                        <section>
+                            <h3>
+                                1: Service/task name
+                            </h3>
+                            <p>
+                                Presents the name of the service/task and the currently selected step
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element2">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                the service/task name must be a unique H1
+                                            </li>
+                                            <li>
+                                                must be the first component on the page
+                                            </li>
+                                            <li>
+                                                for all steps, the service/task name should use the following convention:
+                                                <ul>
+                                                    <li>
+                                                        [Service/task name]: Step #. [Step name]
+                                                    </li>
+                                                    <li>
+                                                        for example, Apply for Employment Insurance: Step 2. Eligibility
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                2: Institutional byline
+                            </h3>
+                            <p>
+                                Provides a link to the institution, organization or partnering/collaborative arrangement entity responsible for the content of the page
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element4">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                use the Institutional byline pattern
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                3: Service steps
+                            </h3>
+                            <p>
+                                Shows links to each step in initiating the service and highlights the currently selected step
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element5">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                use to start tasks that involve complex processes (for example, applying for a grant or funding, registering a business, etc.) or that include detailed prerequisites prior to starting the task
+                                                (for example, eligibility criteria that must be met, or documents or information that must be in hand)
+                                            </li>
+                                            <li>
+                                                label the sequence of steps similar to the tone and wording used in the following example:
+                                                <ol>
+                                                    <li>
+                                                        What this service offers
+                                                    </li>
+                                                    <li>
+                                                        Who is eligible
+                                                    </li>
+                                                    <li>
+                                                        What you need before you start
+                                                    </li>
+                                                    <li>
+                                                        How to apply
+                                                    </li>
+                                                    <li>
+                                                        After you apply
+                                                    </li>
+                                                </ol>
+                                                <ul>
+                                                    <li>
+                                                        Contact us for help
+                                                    </li>
+                                                    <li>
+                                                        More information (background info, related tasks, etc.)
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                when additional unordered pages are included (for example, “more information”):
+                                                <ul>
+                                                    <li>
+                                                        they should not include any information necessary for completing steps in the primary task sequence
+                                                    </li>
+                                                    <li>
+                                                        they should always appear after the numbered steps
+                                                    </li>
+                                                    <li>
+                                                        they should not be numbered
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                or, for simpler, single-step tasks with additional unordered (not numbered) pages, drop the numbers and label pages more like this:
+                                                <ul>
+                                                    <li>
+                                                        How to apply
+                                                    </li>
+                                                    <li>
+                                                        Contact us for help
+                                                    </li>
+                                                    <li>
+                                                        More information (background info, related tasks, etc.)
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element6">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                appears below the institutional byline
+                                            </li>
+                                            <li>
+                                                the
+                                                <a href="../common-design-patterns/ordered-multipage.html">
+                                                    Ordered multi-page navigation pattern
+                                                </a>
+                                                is used to present service steps
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                4. Service content
+                            </h3>
+                            <p>
+                                Provides pertinent details about the current step in the service
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element7">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                content for each step must be complete and avoid the use of hyperlinks out of the current sequence to avoid disrupting the task flow.
+                                                <ul>
+                                                    <li>
+                                                        if you must include links to additional information, use a dismissible overlay or a collapsible details/summary element to keep people inside the service initiation page set
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                on pages describing eligibility criteria, consider using the
+                                                <a href="../common-design-patterns/interactive-questions.html">
+                                                    Interactive questions pattern
+                                                </a>
+                                                to make the requirements more easily understood
+                                            </li>
+                                            <li>
+                                                keep text short and concise
+                                            </li>
+                                            <li>
+                                                written for a grade 6-8 reading level
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element8">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                appears below the service steps
+                                            </li>
+                                            <li>
+                                                do not hyphenate words at the end of lines; retain ragged right edge for paragraphs and other text blocks
+                                            </li>
+                                            <li>
+                                                use Common design patterns for destination content
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                5: Service standards and performance status
+                            </h3>
+                            <p>
+                                Provides service standards people can reasonably expect to encounter under normal circumstances, and indicates the current real-time performance status of the service, whether performing as expected or not
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element9">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                introduce service standards with a plain language heading that focuses on what people can reasonably expect under normal circumstances. Speak directly to a person. Examples:
+                                                <ul>
+                                                    <li>
+                                                        “How long it will take to process your application”
+                                                    </li>
+                                                    <li>
+                                                        Application processing time”
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                include the current standard, the current performance status, how often the report is updated, and when current performance status was last updated. Example:
+                                                <ul>
+                                                    <li>
+                                                        <p>
+                                                            "Our standard is to process applications in 30 business days. Applications are currently being processed in 17 business days.
+                                                        </p>
+                                                        <p>
+                                                            Current processing time is updated daily - last update January 31, 2020."
+                                                        </p>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                you can use colour to add additional information about the status. Green (#278400) can be used to indicate that the current performance status is within the standard, and red (#D3080C) to
+                                                indicate that it is not meeting the standard. (You must also indicate the current performance standard in text.)
+                                            </li>
+                                            <li>
+                                                written for a grade 6-8 reading level
+                                            </li>
+                                            <li>
+                                                keep text short and concise
+                                            </li>
+                                            <li>
+                                                this component is intended to meet the
+                                                <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603">
+                                                    Policy on Service and Digital
+                                                </a>
+                                                requirement to provide service standards on Canada.ca
+                                            </li>
+                                            <li>
+                                                the
+                                                <a href="https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=28422">
+                                                    Guideline on Service Management
+                                                </a>
+                                                contains definitions, characteristics and examples of service standards
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element10">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                appears on pages where people will initiate the service (for example, How to apply) and post-application pages (for example, After you apply)
+                                            </li>
+                                            <li>
+                                                appears for each available channel service/task (for example, in “Other ways to apply”)
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                6: Disclaimer
+                            </h3>
+                            <p>
+                                Provides a link to the service’s terms of use
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element11">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                use this component if there are applicable terms of use (for example, legal disclaimer, privacy policy)
+                                            </li>
+                                            <li>
+                                                written for a grade 6-8 reading level
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element12">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                appears directly above the initiation button/link
+                                            </li>
+                                            <li>
+                                                use the
+                                                <a href="../common-design-patterns/disclaimer-overlay.html">
+                                                    Disclaimer overlay pattern
+                                                </a>
+                                                pattern
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                7: Initiation button/link
+                            </h3>
+                            <p>
+                                Serves as a link to the digital service
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element13">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                provides a link to initiate digital service or a download
+                                            </li>
+                                            <li>
+                                                use only once in the sequence of steps for the current task/service
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element14">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                use the
+                                                <a href="../common-design-patterns/buttons.html">
+                                                    Buttons
+                                                </a>
+                                                pattern or the
+                                                <a href="../common-design-patterns/download-links.html">
+                                                    Download links
+                                                </a>
+                                                pattern
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                8: Other ways to access the service
+                            </h3>
+                            <p>
+                                Provides alternative channels available to access this service, as well as associated service standards and performance status
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element15">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                provides contact details, service standards and service status messages for all alternative channels (for example, in-person, telephone and mail options) available to access this service
+                                            </li>
+                                            <li>
+                                                for each alterative channel, include contact information preceded by the applicable service standard and service status messages
+                                            </li>
+                                            <li>
+                                                limit service standards associated with each alternative channel to 1 or 2 sentences
+                                            </li>
+                                            <li>
+                                                written for a grade 6-8 reading level
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li id="element16">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                appears below the initiation link
+                                            </li>
+                                            <li>
+                                                heading is labelled “Other ways to [apply]”
+                                            </li>
+                                            <li>
+                                                subheadings include options like “By phone”, “In person”, and “By mail”
+                                            </li>
+                                            <li>
+                                                may appear inside a collapsible details/summary element when alternate channels represent a small proportion of demand for this service
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                        <section>
+                            <h3>
+                                9: Previous/next links
+                            </h3>
+                            <p>
+                                Provides a means to navigate to the next or previous page from the bottom of a page
+                            </p>
+                            <ul class="list-unstyled">
+                                <li id="element17">
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Content
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                use this component if the service steps pattern is also being used
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                                <li>
+                                    <details class="mrgn-bttm-sm">
+                                        <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                                            <strong>
+                                                Presentation
+                                            </strong>
+                                        </summary>
+                                        <ul>
+                                            <li>
+                                                go to
+                                                <a href="../common-design-patterns/ordered-multipage.html">
+                                                    Ordered multi-page navigation pattern
+                                                </a>
+                                                for how to present previous/next links
+                                            </li>
+                                        </ul>
+                                    </details>
+                                </li>
+                            </ul>
+                        </section>
+                    </section>
+                </div>
+            </div>
+        </section>
+        <section>
+            <h2 id="navigation">
+                User navigation
+            </h2>
+            <figure class="mrgn-bttm-lg">
+                <figcaption class="text-center">
+                    <b>
+                        User navigation diagram
+                    </b>
+                </figcaption>
+                <img
+                    alt="Diagram of how to navigate to service initiation pages on Canada.ca. Text version below:"
+                    class="img-responsive center-block"
+                    src="https://www.canada.ca/content//dam/tbs-sct/images/government-communications/canada-content-style-guide/service-initiation-pages-ia-eng.png"
+                />
+                <details>
+                    <summary class="wb-toggle" data-toggle='{"print":"on"}'>
+                        Text version
+                    </summary>
+                    <p>
+                        Service initiation pages can be accessed from Canada.ca topic pages and institutional profiles pages.
+                    </p>
+                </details>
+            </figure>
+        </section>
+    </section>
+</div>


### PR DESCRIPTION
Restore the information for the service initiation page pattern, reversing the previous decommissioning changes.

## Alternate language PR
- N/A

## Preview link
- https://deploy-preview-586--design-system-canada-ca.netlify.app/recommended-templates/service-initiation-pages.html