### PR TITLE
Update pr-preview.yml

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build with Jekyll
         if: github.event.action != 'closed'
-        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
+        run: bundle exec jekyll build --config _config.yml,_config.staging.yml --baseurl "/pr-preview/pr-${{ github.event.number }}"
         env:
           JEKYLL_ENV: production
 
@@ -45,6 +45,7 @@ jobs:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           action: auto
+          comment: false
 
       - name: Update PR description with preview
         if: github.event.action != 'closed'
@@ -75,41 +76,45 @@ jobs:
               filesList = '*No content files changed*';
             }
 
-            // Generate preview links for modified HTML and MD files
+            // Generate preview links for modified HTML and MD files (exclude _includes/ and _layouts/)
             const htmlMdFiles = changedFiles.filter(file =>
-              file.endsWith('.md') || file.endsWith('.html')
-            ).slice(0, 10);
+              (file.endsWith('.md') || file.endsWith('.html')) &&
+              !file.startsWith('_includes/') && !file.startsWith('_layouts/')
+            );
 
             let previewLinks = '';
             if (htmlMdFiles.length > 0) {
-              previewLinks = htmlMdFiles.map(file => {
+              previewLinks = htmlMdFiles.slice(0, 10).map(file => {
                 let previewPath = file;
                 // Convert .md files to their preview path (remove .md extension)
                 if (file.endsWith('.md')) {
-                  previewPath = file.replace(/\/index\.md$/, '/').replace(/\.md$/, '/');
+                  previewPath = file.replace(/\/index\.md$/, '/').replace(/\.md$/, '.html');
                 }
                 const previewFile = `https://design.canada.ca/pr-preview/pr-${{ github.event.number }}/${previewPath}`;
-                return `[${file}](${previewFile})`;
-              }).join(' | ');
+                return `- [${file}](${previewFile})`;
+              }).join('<br>');
+              if (htmlMdFiles.length > 10) {
+                previewLinks += `<br>- *...and ${htmlMdFiles.length - 10} more files*`;
+              }
             } else {
-              previewLinks = `[View preview](${previewUrl})`;
+              previewLinks = `- [View preview](${previewUrl})`;
             }
 
-            // Filter for other files changed (CSS, JS, YAML, JSON, images)
+            // Filter for other files changed (CSS, JS, YAML, JSON, images, and HTML from _includes/_layouts)
             const otherFiles = changedFiles.filter(file =>
-              /\.(css|js|ya?ml|json|png|jpg|jpeg|gif|svg|webp)$/i.test(file)
+              /\.(css|js|ya?ml|json|png|jpg|jpeg|gif|svg|webp)$/i.test(file) ||
+              (file.endsWith('.html') && (file.startsWith('_includes/') || file.startsWith('_layouts/')))
             ).slice(0, 10);
 
-            let otherFilesSection = '';
+            let otherFilesContent = '';
             if (otherFiles.length > 0) {
-              let otherFilesList = otherFiles.map(file =>
+              otherFilesContent = otherFiles.map(file =>
                 `- [${file}](https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/${file})`
-              ).join('\n');
+              ).join('<br>');
               if (changedFiles.length > otherFiles.length + htmlMdFiles.length) {
                 const remaining = changedFiles.length - otherFiles.length - htmlMdFiles.length;
-                otherFilesList += `\n- *...and ${remaining} more files*`;
+                otherFilesContent += `<br>- *...and ${remaining} more files*`;
               }
-              otherFilesSection = `\n\n### 📝 Other files changed\n${otherFilesList}`;
             }
 
             // Get current PR body
@@ -137,7 +142,7 @@ jobs:
               currentBody = currentBody.substring(0, markerIndex).trim();
             }
 
-            const previewSection = `\n\n## Alternate language PR\n${alternateLangLink}\n\n---\n\n## 🚀 PR Preview\n\n| Name | Link |\n|------|------|\n| **Latest commit** | [${context.payload.pull_request.head.sha.substring(0, 7)}](${commitUrl}) |\n| **Deploy preview** | ${previewLinks} |${otherFilesSection}\n\n---\n*Preview updates automatically with each commit*`;
+            const previewSection = `## Alternate language PR\n${alternateLangLink}\n\n---\n\n## 🚀 PR Preview\n\n| Name | Link(s) |\n|------|------|\n| **Latest commit** | [${context.payload.pull_request.head.sha.substring(0, 7)}](${commitUrl}) |\n| **Page preview** | ${previewLinks} |${otherFilesContent ? `\n| **Other changed files** | ${otherFilesContent} |` : ''}\n\n---\n*<small>Preview updates automatically with each commit*</small>`;
 
             // Update PR description
             await github.rest.pulls.update({

--- a/_config.staging.yml
+++ b/_config.staging.yml
@@ -3,4 +3,4 @@ analytics:
     adobe:
       tracking_id: "be5dfd287373/0127575cd23a/launch-913b1beddf7a-staging"
       service: "ESDC_TEST-TEST_EDSC"
-url: "DEPLOY_PRIME_URL"
+url: "https://design.canada.ca"

--- a/_config.yml
+++ b/_config.yml
@@ -121,7 +121,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           }
         ]
@@ -137,7 +137,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
@@ -145,7 +145,7 @@
             "title": "Templates and patterns"
           },
           {
-            "link": "https://design.canada.ca/recommended-templates/generic-destination.html",
+            "link": "/recommended-templates/generic-destination.html",
             "title": "Generic destination template"
           }
         ]
@@ -166,7 +166,7 @@
           },
           {
             "title": "GC Task Success Survey",
-            "link": "https://design.canada.ca/survey/index.html"
+            "link": "/survey/index.html"
           }
         ]
       }
@@ -182,11 +182,11 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Information architecture specification",
-            "link": "https://design.canada.ca/architecture/canada-content-information-architecture-specification.html"
+            "link": "/architecture/canada-content-information-architecture-specification.html"
           }
         ]
       }
@@ -202,11 +202,11 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Templates and patterns",
-            "link": "https://design.canada.ca/pattern-library.html"
+            "link": "/pattern-library.html"
           }
         ]
       }
@@ -222,15 +222,15 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Templates and patterns",
-            "link": "https://design.canada.ca/pattern-library.html"
+            "link": "/pattern-library.html"
           },
           {
             "title": "Global header",
-            "link": "https://design.canada.ca/common-design-patterns/global-header.html"
+            "link": "/common-design-patterns/global-header.html"
           }
         ],
         "permalink": "/common-design-patterns/:basename:output_ext"
@@ -247,15 +247,15 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Templates and patterns",
-            "link": "https://design.canada.ca/pattern-library.html"
+            "link": "/pattern-library.html"
           },
           {
             "title": "Global footer",
-            "link": "https://design.canada.ca/common-design-patterns/site-footer.html"
+            "link": "/common-design-patterns/site-footer.html"
           }
         ],
         "permalink": "/common-design-patterns/:basename:output_ext"
@@ -271,11 +271,11 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
-            "link": "https://design.canada.ca/community/landing.html",
+            "link": "/community/landing.html",
             "title": "Community"
           }
         ]
@@ -291,11 +291,11 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
-            "link": "https://design.canada.ca/continuous-improvement.html",
+            "link": "/continuous-improvement.html",
             "title": "Continuous improvement"
           }
         ]
@@ -311,7 +311,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           }
         ]
@@ -327,11 +327,11 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
-            "link": "https://design.canada.ca/crisis/content.html",
+            "link": "/crisis/content.html",
             "title": "Crisis communications content design checklist"
           }
         ]
@@ -352,7 +352,7 @@
           },
           {
             "title": "Page feedback",
-            "link": "https://design.canada.ca/feedback/index.html"
+            "link": "/feedback/index.html"
           }
         ]
       }
@@ -367,11 +367,11 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
-            "link": "https://design.canada.ca/guidance",
+            "link": "/guidance",
             "title": "Guidance"
           }
         ]
@@ -387,7 +387,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
@@ -407,7 +407,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
@@ -427,7 +427,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
@@ -447,7 +447,7 @@
             "title": "About Canada.ca"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           },
           {
@@ -468,11 +468,11 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Canada.ca Content Style Guide",
-            "link": "https://design.canada.ca/style-guide/"
+            "link": "/style-guide/"
           }
         ]
       }
@@ -488,7 +488,7 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           }
         ]
       }
@@ -503,7 +503,7 @@
             "link": "https://www.canada.ca/en/government/about-canada-ca.html"
           },
           {
-            "link": "https://design.canada.ca/",
+            "link": "/",
             "title": "Design"
           }
         ]
@@ -539,11 +539,11 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Canada.ca Content Style Guide",
-            "link": "https://design.canada.ca/style-guide/"
+            "link": "/style-guide/"
           }
         ]
       }
@@ -559,10 +559,10 @@
             "link": "https://www.canada.ca/en/government/about-canada-ca.html"
           },{
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },{
             "title": "Research summaries",
-            "link": "https://design.canada.ca/research-summaries/"
+            "link": "/research-summaries/"
           }
         ]
       }
@@ -578,7 +578,7 @@
           "link": "https://www.canada.ca/en/government/about-canada-ca.html"
         },{
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           }]
       }
     },
@@ -594,7 +594,7 @@
           },
           {
             "title": "Working with partners",
-            "link": "https://design.canada.ca/partners/"
+            "link": "/partners/"
           }
         ]
       }
@@ -622,7 +622,7 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           }
         ]
       }
@@ -638,11 +638,11 @@
           },
           {
             "title": "Design",
-            "link": "https://design.canada.ca/"
+            "link": "/"
           },
           {
             "title": "Templates and patterns",
-            "link": "https://design.canada.ca/pattern-library.html"
+            "link": "/pattern-library.html"
           }
         ]
       }

--- a/_includes/breadcrumbs/breadcrumbs.html
+++ b/_includes/breadcrumbs/breadcrumbs.html
@@ -1,0 +1,40 @@
+{%- unless page.pageclass contains "home" or page.breadcrumbs == false or layout.breadcrumbs == false -%}
+<nav id="wb-bc" property="breadcrumb">
+	<h2>{{ i18nText-breadcrumb }}</h2>
+	<div class="container">
+		<ol class="breadcrumb" typeof="BreadcrumbList">
+			<li property="itemListElement" typeof="ListItem">
+				<a property="item" typeof="WebPage" href="{{ i18nText-homePage }}">
+					<span property="name">{{ i18nText-home }}</span>
+				</a>
+				<meta property="position" content="1">
+			</li>
+			{% assign breadcrumbCounter = 2 %}
+			{%- unless page.overwriteBreadcrumbs -%}
+				{%- if site.global.breadcrumbs -%}
+					{% for breadcrumb in site.global.breadcrumbs[i18nText-lang] %}
+							<li property="itemListElement" typeof="ListItem">
+								<a property="item" typeof="WebPage" href="{% if breadcrumb.link contains 'http' %}{{ breadcrumb.link }}{% else %}{{ breadcrumb.link | absolute_url }}{% endif %}">
+									<span property="name">{{ breadcrumb.title }}</span>
+								</a>
+								<meta property="position" content="{{ breadcrumbCounter }}">
+							</li>
+							{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
+					{%- endfor -%}
+				{% endif %}
+			{%- endunless -%}
+			{%- if page.breadcrumbs -%}
+				{% for breadcrumb in page.breadcrumbs %}
+						<li property="itemListElement" typeof="ListItem">
+							<a property="item" typeof="WebPage" href="{% if breadcrumb.link contains 'http' %}{{ breadcrumb.link }}{% else %}{{ breadcrumb.link | absolute_url }}{% endif %}">
+								<span property="name">{{ breadcrumb.title }}</span>
+							</a>
+							<meta property="position" content="{{ breadcrumbCounter }}">
+						</li>
+						{% assign breadcrumbCounter = breadcrumbCounter | plus:1 %}
+				{%- endfor -%}
+			{% endif %}
+		</ol>
+	</div>
+</nav>
+{% endunless %}

--- a/_includes/json-ld-site.html
+++ b/_includes/json-ld-site.html
@@ -20,7 +20,7 @@
         "@type": "WebSite",
         {% if site.name %}"name": "{{ site.name }}",{% endif %}
         {% if site.description %}"description": "{{ site.description }}",{% endif %}
-        {% if site.url %}"url": "{{ site.url }}{{ site.baseurl }}",{% endif %}
+        {% if site.url %}"url": "{{ '/' | absolute_url }}",{% endif %}
         {% if site.author %}"author":
             {
                 "@type": "Person",

--- a/community/landing.md
+++ b/community/landing.md
@@ -3,8 +3,8 @@ altLangPage: https://conception.canada.ca/communaute/accueil.html
 breadcrumbs:
 - link: https://www.canada.ca/en/government/about.html
   title: About Canada.ca
-- link: https://www.canada.ca/en/government/about/design-system.html
-  title: Canada.ca design system
+- link: /
+  title: Design
 date: null
 dateModified: '2020-10-30'
 description: null

--- a/crisis/content.md
+++ b/crisis/content.md
@@ -3,8 +3,8 @@ altLangPage: https://conception.canada.ca/crise/contenu.html
 breadcrumbs:
 - link: https://www.canada.ca/en/government/about.html
   title: About Canada.ca
-- link: https://www.canada.ca/en/government/about/design-system.html
-  title: Canada.ca design system
+- link: /
+  title: Design
 date: null
 dateModified: '2021-12-21'
 description: null
@@ -13,7 +13,7 @@ title: Crisis communications content design checklist
 
 
 <div>
- 
+
  <section>
   <h2>
    On this page

--- a/guidance/index.md
+++ b/guidance/index.md
@@ -32,7 +32,7 @@ Use this guidance to create and manage web content.
 	<div class="row wb-eqht-grd">
 		{%- for info in page.information -%}
 		<div class="col-lg-4 col-md-6">
-			<h3><a href="{{ site.url }}{{ info.link }}">{{ info.title }}</a></h3>
+			<h3><a href="{{ info.link | absolute_url }}">{{ info.title }}</a></h3>
       <p>{{ info.description }}</p>
 		</div>
 		{%- endfor -%}

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ information:
     link: /research-summaries/
     description: Research done to make it easier for people to find and understand Government of Canada information and services
   - title: About Canada.ca
-    link: /about/
+    link: https://www.canada.ca/en/government/about-canada-ca.html
     description: Most requested, analytics for Canada.ca, Government of Canada contacts
   - title: Canada.ca design guidance
     link: /guidance/index.html
@@ -36,7 +36,7 @@ title: "Canada.ca design"
       {% if info.link contains 'http' %}
         <h3><a href="{{ info.link }}">{{ info.title }}</a></h3>
       {% else %}
-        <h3><a href="{{ site.url }}{{ info.link }}">{{ info.title }}</a></h3>
+        <h3><a href="{{ info.link | absolute_url }}">{{ info.title }}</a></h3>
       {% endif %}
       <p>{{ info.description }}</p>
     </div>


### PR DESCRIPTION
When using Jekyll with GitHub Pages PR previews, internal links need special handling to work correctly with the dynamic preview paths. Here's what was implemented:

### 1. Workflow configuration (`.github/workflows/pr-preview.yml`)

**Key features:**
- **Dynamic baseurl**: Pass `--baseurl "/pr-preview/pr-${{ github.event.number }}"` during Jekyll build
- **Disable bot comments**: Set `comment: false` in pr-preview-action to avoid duplicate notifications
- **Smart preview links**: Generate preview URLs for changed HTML/MD files, excluding `_includes/` and `_layouts/`
- **Custom PR description**: Auto-update PR with formatted preview links and changed files list

### 2. Configuration files
**`_config.yml`** - Base configuration includes:
- `baseurl: ""` - Empty by default, overridden by `--baseurl` CLI argument
- `url: "https://design.canada.ca"` - Production domain

### 3. Liquid filter conversions

**Critical pattern change**: Replace `{{ site.url }}{{ path }}` with `{{ path | absolute_url }}` to properly include baseurl.

**Files updated:**

**`_includes/breadcrumbs/breadcrumbs.html`** - Breadcrumb navigation
**`_includes/json-ld-site.html`** - Schema.org structured data
**`index.md`** - Home page service links

### Why this matters

**Jekyll's baseurl mechanism only applies to Liquid-filtered URLs**, not raw concatenations:
- ❌ `{{ site.url }}/path` → `https://design.canada.ca/path` (missing baseurl)
- ✅ `{{ '/path' | relative_url }}` → `/pr-preview/pr-628/path` (includes baseurl)
- ✅ `{{ '/path' | absolute_url }}` → `https://design.canada.ca/pr-preview/pr-628/path` (full URL with baseurl)