### PR TITLE
fix: harden gh-pages deploy (preserve previews, keep CNAME) and bump actions to Node 24

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -5,6 +5,10 @@ on:
     # Run every day at 2:00 AM UTC
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual trigger
+    inputs:
+      retention_days:
+        description: 'Days to keep previews after a PR closes'
+        default: '7'
 
 permissions:
   contents: write
@@ -15,13 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
           fetch-depth: 0
 
       - name: Clean up stale preview directories
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
+        env:
+          RETENTION_DAYS: ${{ inputs.retention_days || 7 }}
         with:
           script: |
             const fs = require('fs');
@@ -29,7 +35,21 @@ jobs:
             const { execSync } = require('child_process');
 
             // Configuration
-            const RETENTION_DAYS = 7; // Keep previews for PRs closed within this many days
+            // pr-preview.yml deliberately ignores closed events, so this scheduled
+            // workflow is the only thing that prunes previews.
+            // Keep previews for PRs closed within this many days. Scheduled runs
+            // supply no inputs, so fall back to 7; an explicit 0 is honoured
+            // (prune everything already closed), but blank or invalid values
+            // are not.
+            const rawRetentionDays = process.env.RETENTION_DAYS;
+            const parsedRetentionDays = Number(rawRetentionDays);
+            const RETENTION_DAYS = (rawRetentionDays !== '' && Number.isFinite(parsedRetentionDays) && parsedRetentionDays >= 0)
+              ? parsedRetentionDays
+              : 7;
+
+            const retentionMs = RETENTION_DAYS * 24 * 60 * 60 * 1000;
+            const cutoffDate = new Date(Date.now() - retentionMs);
+            const cutoffDateString = cutoffDate.toISOString().slice(0, 10);
 
             // Helper function to safely extract error information
             function extractErrorInfo(error) {
@@ -50,27 +70,21 @@ jobs:
               per_page: 100
             });
 
-            const closedPRs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              per_page: 100,
-              sort: 'updated',
-              direction: 'desc'
+            const recentlyClosedPRs = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr closed:>=${cutoffDateString}`,
+              per_page: 100
             });
 
             // Keep previews for open PRs and PRs closed in the last N days
-            const retentionMs = RETENTION_DAYS * 24 * 60 * 60 * 1000;
-            const cutoffDate = new Date(Date.now() - retentionMs);
             const activePRNumbers = new Set([
               ...openPRs.map(pr => pr.number),
-              ...closedPRs
+              ...recentlyClosedPRs
                 .filter(pr => pr.closed_at && new Date(pr.closed_at) > cutoffDate)
                 .map(pr => pr.number)
             ]);
 
             console.log(`Retention period: ${RETENTION_DAYS} days`);
-            console.log(`Active PR numbers to keep: ${Array.from(activePRNumbers).join(', ')}`);
+            console.log(`Active PR numbers to keep: ${activePRNumbers.size}`);
 
             // Check if pr-preview directory exists
             const previewDir = 'pr-preview';
@@ -84,7 +98,7 @@ jobs:
               .filter(dir => dir.startsWith('pr-'))
               .map(dir => {
                 const match = dir.match(/^pr-(\d+)$/);
-                return match ? { dir, prNumber: parseInt(match[1]) } : null;
+                return match ? { dir, prNumber: parseInt(match[1], 10) } : null;
               })
               .filter(x => x !== null);
 
@@ -109,7 +123,7 @@ jobs:
             staleDirectories.forEach(({ dir }) => {
               const dirPath = path.join(previewDir, dir);
               try {
-                execSync(`rm -rf "${dirPath}"`, { stdio: 'inherit' });
+                fs.rmSync(dirPath, { recursive: true, force: true });
                 console.log(`Removed: ${dirPath}`);
               } catch (error) {
                 const { message } = extractErrorInfo(error);

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -43,13 +43,24 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Preserve PR previews
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch --no-tags --depth=1 origin gh-pages
+            if git cat-file -e FETCH_HEAD:pr-preview 2>/dev/null; then
+              mkdir -p _site
+              git archive FETCH_HEAD pr-preview | tar -x -C _site
+              echo "Preserved $(ls -1 _site/pr-preview | wc -l) PR preview director(ies)"
+            else
+              echo "gh-pages has no pr-preview directory; nothing to preserve"
+            fi
+          else
+            echo "no gh-pages branch yet; nothing to preserve"
+          fi
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
-          # keep_files is intentionally set to true so that existing content (including PR preview directories)
-          # is not deleted on each deploy. Old preview directories are periodically cleaned up by
-          # .github/workflows/cleanup-previews.yml to prevent unbounded growth of the gh-pages branch.
-          keep_files: true
           publish_branch: gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -6,7 +6,10 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
+#      Preview deletion on close is intentionally disabled here.
+#      .github/workflows/cleanup-previews.yml keeps closed PR previews
+#      for RETENTION_DAYS before pruning them.
+#      - closed
 
 # Sets permissions of the GITHUB_TOKEN to allow pushing to gh-pages
 permissions:
@@ -22,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Ruby
         if: github.event.action != 'closed'
@@ -49,7 +52,7 @@ jobs:
 
       - name: Update PR description with preview
         if: github.event.action != 'closed'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const previewUrl = `https://design.canada.ca/pr-preview/pr-${{ github.event.number }}/`;
@@ -176,7 +179,7 @@ jobs:
 
       - name: Remove preview from PR description
         if: github.event.action == 'closed'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Get current PR body

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,6 @@
     "*.gpg",
     "*.py",
     "*.tmp",
-    "CNAME",
     "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "design-system.code-workspace",


### PR DESCRIPTION
> [!IMPORTANT]
> **Scope note.** This PR was originally the Node 24 version bumps alone, and was approved on that basis. It now also changes **how production deploys to `gh-pages`**, in step with the review feedback on the French companion PR canada-ca/systeme-conception#590. The deploy change has not been reviewed yet — please re-review.

## Problem

**1. Stale files linger at the site root.** `jekyll.yml` publishes production to the `gh-pages` branch root with `peaceiris/actions-gh-pages` and `keep_files: true`, which never deletes anything. Files removed from the site stay reachable at their old URLs indefinitely.

**2. Node 20 deprecation warnings.** Every workflow run prints:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, ...

GitHub deprecated Node 20 on Actions runners ([changelog, 2025-09-19](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)); actions still declaring `node20` are forced onto Node 24 and warn on every run. Harmless today, but these pins will break when Node 20 support is fully removed.

## Fix

### Deploy — `jekyll.yml`, `_config.yml`

- Drop `keep_files: true`, so the deploy replaces the `gh-pages` root and stale files are cleared.
- Add a `Preserve PR previews` step that copies the existing `pr-preview/` tree off `gh-pages` into `_site` before publishing, so live previews survive. Verified by **executing that step against the real `gh-pages` branch**: 5 preview directories preserved.
- Remove `"CNAME"` from the `exclude` array in `_config.yml`. **This is load-bearing:** `CNAME` was excluded from the build, so `_site` contained no `CNAME`, and the custom domain survived only because `keep_files: true` left the existing one on the `gh-pages` root untouched. Dropping `keep_files` without this would have taken design.canada.ca offline on the first deploy. Verified: a real `bundle exec jekyll build` now emits `_site/CNAME`.

### Preview cleanup — `cleanup-previews.yml`

- Scope the closed-PR lookup to the retention window with the Search API, instead of paginating every closed PR in the repo.
- Log a count rather than every active PR number.
- Use `fs.rmSync(dirPath, { recursive: true, force: true })` instead of shelling out to `rm -rf`.
- Pass an explicit radix to `parseInt`.
- Behaviour note: the search query is day-granular, so previews are retained to the **start** of the cutoff day (up to ~8 days rather than exactly 7). It errs toward keeping previews longer and never prunes early.

### Node 24 bumps (the original change)

Drop-in major bumps across `jekyll.yml`, `pr-preview.yml`, and `cleanup-previews.yml`:

- `actions/checkout` v4 → v5
- `actions/github-script` v7 → v8

Verified runtimes of everything else in use: `ruby/setup-ruby@v1` and `peaceiris/actions-gh-pages@v4` already declare `node24`; `rossjrw/pr-preview-action@v1` is a composite action.

## Known trade-off

With `keep_files: true`, a PR preview pushed during a production deploy was never at risk. There is now a narrow window: a preview pushed between the step that reads `gh-pages` and the deploy that publishes `_site` would be overwritten. The next preview push for that PR restores it.

This is accepted as an interim state. The publish process is set to be rearchitected into dedicated repositories for preview hosting and for `gh-pages` production hosting, with the source repos kept for contribution — five repos in total — which removes the shared-branch contention this trade-off comes from.

## After merging

1. Confirm **Settings → Pages → Build and deployment → Source** is still "Deploy from a branch: `gh-pages` / (root)".
2. Spot-check that https://design.canada.ca still resolves (CNAME) and that an open PR's `/pr-preview/pr-N/` still serves.

## Alternate language PR
- https://github.com/canada-ca/systeme-conception/pull/590

---

## 🚀 PR Preview

| Name | Link(s) |
|------|----------|
| **Latest commit** | [d48e43c](https://github.com/canada-ca/design-system/commit/d48e43c811e393046beafdd900a6495669d92fe6) |
| **Page preview** | - [View preview](https://design.canada.ca/pr-preview/pr-715/) |
| **Other changed files** | - [.github/workflows/cleanup-previews.yml](https://github.com/canada-ca/design-system/blob/d48e43c811e393046beafdd900a6495669d92fe6/.github/workflows/cleanup-previews.yml)<br>- [.github/workflows/jekyll.yml](https://github.com/canada-ca/design-system/blob/d48e43c811e393046beafdd900a6495669d92fe6/.github/workflows/jekyll.yml)<br>- [.github/workflows/pr-preview.yml](https://github.com/canada-ca/design-system/blob/d48e43c811e393046beafdd900a6495669d92fe6/.github/workflows/pr-preview.yml)<br>- [_config.yml](https://github.com/canada-ca/design-system/blob/d48e43c811e393046beafdd900a6495669d92fe6/_config.yml) |

---
*<small>Preview updates automatically with each commit*</small>
