### PR TITLE
docs: remove 2023 design update banner from Global header pattern

### DIFF
--- a/common-design-patterns/global-header.md
+++ b/common-design-patterns/global-header.md
@@ -21,7 +21,6 @@ title: "Global header"
   <li>provides a unified experience on the Government of Canada web presence</li>
   <li>allows navigation across the broad range of services and information offered</li>
 </ul>
-<p><strong>2023 design update</strong>: We’ve recently updated this pattern as part of a new navigation strategy coming out of the Wayfinding research project. To find out more about this project, visit <a href="#research">Research and rationale</a>.</p>
 <div class="pattern-demo mrgn-tp-lg">
   <figure class="mrgn-bttm-sm"><img src="../images/01-sign-in-desktop-en.jpg" class="img-responsive" alt=""></figure>
 </div>

--- a/common-design-patterns/global-header.md
+++ b/common-design-patterns/global-header.md
@@ -22,7 +22,7 @@ title: "Global header"
   <li>allows navigation across the broad range of services and information offered</li>
 </ul>
 <div class="pattern-demo mrgn-tp-lg">
-  <figure class="mrgn-bttm-sm"><img src="../images/01-sign-in-desktop-en.jpg" class="img-responsive" alt=""></figure>
+  <figure class="mrgn-bttm-sm"><img src="../images/01-sign-in-desktop-en.jpg" class="img-responsive" alt="A screenshot of the global Canada.ca header."></figure>
 </div>
 <section>
   <h2>On this page</h2>


### PR DESCRIPTION
The banner announcing the Wayfinding navigation strategy update is no longer current. The Research and rationale section still covers the Wayfinding project.

Trello card: https://trello.com/c/aH69RLkf
## Alternate language PR
- https://github.com/canada-ca/systeme-conception/pull/598

---

## 🚀 PR Preview

| Name | Link(s) |
|------|----------|
| **Latest commit** | [f6ecfff](https://github.com/canada-ca/design-system/commit/f6ecfffc9e358c701cf6ab008f6536da51f0a1e5) |
| **Page preview** | - [common-design-patterns/global-header.md](https://design.canada.ca/pr-preview/pr-722/common-design-patterns/global-header.html) |

---
*<small>Preview updates automatically with each commit*</small>